### PR TITLE
feat: expose SSE endpoint for collection logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pymongo>=4.6",
     "fastapi>=0.111",
     "uvicorn[standard]>=0.29",
+    "sse-starlette>=2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add an optional status callback to the news collector service so scraping steps can be reported in real time
- expose a /collect/stream FastAPI route that streams log events and the final collection summary via Server-Sent Events
- include the sse-starlette dependency to support SSE responses from the API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc9d7cdf40832babbe8fe76d6d40a4