### PR TITLE
Enforce date placeholder in listing templates

### DIFF
--- a/sentinela/cli.py
+++ b/sentinela/cli.py
@@ -92,7 +92,13 @@ def main() -> None:
     elif args.command == "collect":
         start_date = _parse_date(args.start_date)
         end_date = _parse_date(args.end_date) if args.end_date else start_date
-        articles = container.collector_service.collect(args.portal, start_date, end_date)
+        try:
+            articles = container.collector_service.collect(
+                args.portal, start_date, end_date
+            )
+        except ValueError as exc:
+            print(str(exc))
+            return
         print(f"{len(articles)} novas notícias coletadas para '{args.portal}'.")
     elif args.command == "list-articles":
         start_date = _parse_date(args.start_date)

--- a/sentinela/domain/entities.py
+++ b/sentinela/domain/entities.py
@@ -46,6 +46,11 @@ class Portal:
     def listing_url_for(self, target_date: datetime) -> str:
         """Build the URL used to fetch the listing for a given date."""
 
+        if "{date}" not in self.listing_path_template:
+            raise ValueError(
+                "O template de listagem deve conter '{date}' para coleta por data. "
+                "Use o comando 'collect-all' ou configure listing_path_template com '{date}'."
+            )
         formatted_date = target_date.strftime(self.date_format)
         path = self.listing_path_template.format(date=formatted_date)
         return f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_portal_listing_url.py
+++ b/tests/test_portal_listing_url.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+import pytest
+
+from sentinela.domain.entities import Portal, PortalSelectors, Selector
+
+
+def _build_portal(listing_template: str) -> Portal:
+    selectors = PortalSelectors(
+        listing_article=Selector(query="article"),
+        listing_title=Selector(query="h2"),
+        listing_url=Selector(query="a", attribute="href"),
+        article_content=Selector(query="div.content"),
+        article_date=Selector(query="time", attribute="datetime"),
+    )
+    return Portal(
+        name="example",
+        base_url="https://example.com",
+        listing_path_template=listing_template,
+        selectors=selectors,
+    )
+
+
+def test_listing_url_requires_date_placeholder() -> None:
+    portal = _build_portal("/noticias?page={page}")
+
+    with pytest.raises(ValueError) as excinfo:
+        portal.listing_url_for(datetime(2024, 1, 1))
+
+    message = str(excinfo.value)
+    assert "collect-all" in message
+    assert "{date}" in message


### PR DESCRIPTION
## Summary
- validate that portal listing templates used for date collection include the `{date}` placeholder
- surface a friendly error message in the CLI collect command when the placeholder is missing
- add a regression test covering the `{page}`-only listing template scenario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce199d8904832b9acd9bcd81efca11