### PR TITLE
Add microservice scaffolding for entity extraction

### DIFF
--- a/sentinela/extraction/__init__.py
+++ b/sentinela/extraction/__init__.py
@@ -1,0 +1,43 @@
+"""Entity extraction microservice components."""
+from .models import (
+    CityCandidate,
+    CityOccurrence,
+    CityResolution,
+    EntitySpan,
+    NewsDocument,
+    NormalizedPersonName,
+    PersonOccurrence,
+    ProcessedBatchResult,
+    ExtractionResultWriter,
+    NewsRepository,
+)
+from .gazetteer import CityGazetteer, CityRecord
+from .normalization import (
+    extract_state_mentions,
+    find_sentence_containing,
+    normalize_article_text,
+    normalize_person_name,
+)
+from .service import EntityExtractionService
+from .ner import NEREngine
+
+__all__ = [
+    "CityCandidate",
+    "CityGazetteer",
+    "CityOccurrence",
+    "CityRecord",
+    "CityResolution",
+    "EntityExtractionService",
+    "EntitySpan",
+    "NEREngine",
+    "NewsDocument",
+    "NormalizedPersonName",
+    "PersonOccurrence",
+    "ProcessedBatchResult",
+    "ExtractionResultWriter",
+    "NewsRepository",
+    "extract_state_mentions",
+    "find_sentence_containing",
+    "normalize_article_text",
+    "normalize_person_name",
+]

--- a/sentinela/extraction/gazetteer.py
+++ b/sentinela/extraction/gazetteer.py
@@ -1,0 +1,154 @@
+"""Gazetteer matching utilities for city resolution."""
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+from .models import CityCandidate, CityResolution
+
+
+@dataclass(frozen=True, slots=True)
+class CityRecord:
+    """Representation of an entry in the IBGE gazetteer."""
+
+    id: str
+    name: str
+    uf: str
+    alt_names: tuple[str, ...] = ()
+    latitude: float | None = None
+    longitude: float | None = None
+    country: str = "BR"
+
+    def variants(self) -> List[str]:
+        base = [self.name]
+        base.extend(self.alt_names)
+        normalized_variants = []
+        for value in base:
+            cleaned = value.strip()
+            if cleaned:
+                normalized_variants.append(cleaned)
+        return normalized_variants
+
+
+class CityGazetteer:
+    """Simple in-memory gazetteer resolver."""
+
+    def __init__(self, cities: Iterable[CityRecord]):
+        self._cities: tuple[CityRecord, ...] = tuple(cities)
+        self._by_name: Dict[str, List[CityRecord]] = defaultdict(list)
+        for city in self._cities:
+            for variant in city.variants():
+                self._by_name[self._normalize(variant)].append(city)
+
+    @staticmethod
+    def _normalize(name: str) -> str:
+        return re.sub(r"\s+", " ", name).strip().lower()
+
+    def resolve(
+        self,
+        surface: str,
+        *,
+        uf_surface: str | None,
+        context_states: Iterable[str] | None = None,
+    ) -> CityResolution:
+        """Resolve a city mention to the gazetteer using contextual hints."""
+
+        normalized_surface = self._normalize(surface)
+        candidates = list(self._by_name.get(normalized_surface, []))
+        context_set = set(context_states or [])
+
+        def _make_candidates(entries: Iterable[CityRecord]) -> tuple[CityCandidate, ...]:
+            entries_list = list(entries)
+            if not entries_list:
+                return ()
+            weight = 1.0 / len(entries_list)
+            return tuple(
+                CityCandidate(city_id=c.id, name=c.name, uf=c.uf, score=weight)
+                for c in entries_list
+            )
+
+        if uf_surface:
+            uf_filtered = [c for c in candidates if c.uf.upper() == uf_surface.upper()]
+            if uf_filtered:
+                candidates = uf_filtered
+
+        if not candidates:
+            return CityResolution(
+                city_id=None,
+                surface=surface,
+                start=-1,
+                end=-1,
+                sentence="",
+                status="foreign",
+                uf_surface=uf_surface,
+                method="gazetteer",
+                confidence=0.2,
+                candidates=(),
+            )
+
+        if len(candidates) > 1 and context_set:
+            context_filtered = [c for c in candidates if c.uf.upper() in context_set]
+            if context_filtered:
+                candidates = context_filtered
+
+        if len(candidates) == 1:
+            candidate = candidates[0]
+            return CityResolution(
+                city_id=candidate.id,
+                surface=surface,
+                start=-1,
+                end=-1,
+                sentence="",
+                status="resolved",
+                uf_surface=uf_surface,
+                method="gazetteer",
+                confidence=0.95,
+                candidates=_make_candidates([candidate]),
+            )
+
+        return CityResolution(
+            city_id=None,
+            surface=surface,
+            start=-1,
+            end=-1,
+            sentence="",
+            status="ambiguous",
+            uf_surface=uf_surface,
+            method="gazetteer",
+            confidence=0.5,
+            candidates=_make_candidates(candidates),
+        )
+
+
+_CITY_UF_PATTERN = re.compile(
+    r"(?P<name>[A-ZÁ-ÚÂÊÎÔÛÃÕÇ][\wÀ-ÿ' .-]{2,}?)\s*[-/]\s*(?P<uf>[A-Z]{2})"
+)
+_PREFEITO_PATTERN = re.compile(
+    r"prefeit[ao]a?\s+de\s+(?P<name>[A-ZÁ-ÚÂÊÎÔÛÃÕÇ][\wÀ-ÿ' .-]+)",
+    re.IGNORECASE,
+)
+_MUNICIPIO_PATTERN = re.compile(
+    r"munic[ií]pio\s+de\s+(?P<name>[A-ZÁ-ÚÂÊÎÔÛÃÕÇ][\wÀ-ÿ' .-]+)",
+    re.IGNORECASE,
+)
+
+
+def find_city_pattern_matches(text: str) -> list[tuple[str, tuple[int, int], str | None]]:
+    """Return city candidates based on deterministic patterns."""
+
+    matches: list[tuple[str, tuple[int, int], str | None]] = []
+    for match in _CITY_UF_PATTERN.finditer(text):
+        matches.append((match.group(0).strip(), match.span(), match.group("uf")))
+    for pattern in (_PREFEITO_PATTERN, _MUNICIPIO_PATTERN):
+        for match in pattern.finditer(text):
+            matches.append((match.group("name").strip(), match.span("name"), None))
+    return matches
+
+
+__all__ = [
+    "CityGazetteer",
+    "CityRecord",
+    "find_city_pattern_matches",
+]

--- a/sentinela/extraction/models.py
+++ b/sentinela/extraction/models.py
@@ -1,0 +1,127 @@
+"""Dataclasses and shared models for the entity extraction microservice."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class NewsDocument:
+    """Representation of a news article stored in MongoDB."""
+
+    url: str
+    title: str
+    body: str
+    published_at: datetime
+    source: str | None = None
+
+    def combined_text(self) -> str:
+        """Return the text to be analysed by the NER pipeline."""
+
+        parts = [part.strip() for part in (self.title, self.body) if part]
+        return "\n".join(part for part in parts if part)
+
+
+@dataclass(frozen=True, slots=True)
+class EntitySpan:
+    """Entity mention identified by the NER engine or rules."""
+
+    label: str
+    text: str
+    start: int
+    end: int
+    score: float
+    method: str = "ner"
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedPersonName:
+    """Canonical representation for a person mention."""
+
+    canonical_name: str
+    aliases: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonOccurrence:
+    """Occurrence of a person mention inside a news article."""
+
+    person_id: str
+    canonical_name: str
+    surface: str
+    start: int
+    end: int
+    sentence: str
+    method: str
+    confidence: float
+
+
+@dataclass(frozen=True, slots=True)
+class CityCandidate:
+    """Candidate resolution for a city mention."""
+
+    city_id: str
+    name: str
+    uf: str
+    score: float
+
+
+@dataclass(frozen=True, slots=True)
+class CityOccurrence:
+    """Representation of a city mention in a news article."""
+
+    city_id: str | None
+    surface: str
+    start: int
+    end: int
+    sentence: str
+    status: str
+    uf_surface: str | None
+    method: str
+    confidence: float
+    candidates: tuple[CityCandidate, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CityResolution(CityOccurrence):
+    """Alias for readability when returning resolved city information."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessedBatchResult:
+    """Outcome summary for a processed batch of news."""
+
+    processed: int
+    errors: tuple[tuple[str, str], ...]
+    skipped_empty: int = 0
+
+
+class NewsRepository(Protocol):
+    """Abstraction over MongoDB access used by the extraction microservice."""
+
+    def fetch_pending(
+        self, batch_size: int, ner_version: str, gazetteer_version: str
+    ) -> Iterable[NewsDocument]:
+        """Retrieve a batch of articles pending entity extraction."""
+
+    def mark_processed(
+        self, url: str, ner_version: str, gazetteer_version: str, processed_at: datetime
+    ) -> None:
+        """Mark a document as processed with the given versions."""
+
+    def mark_error(self, url: str, message: str) -> None:
+        """Register that a document failed to be processed."""
+
+
+class ExtractionResultWriter(Protocol):
+    """Persists entities and relations into the relational store."""
+
+    def ensure_person(self, canonical_name: str, aliases: set[str]) -> str:
+        """Return the identifier of the person, inserting if necessary."""
+
+    def record_person_occurrence(self, url: str, occurrence: PersonOccurrence) -> None:
+        """Persist the relation between the news and the person occurrence."""
+
+    def record_city_occurrence(self, url: str, occurrence: CityOccurrence) -> None:
+        """Persist the relation between the news and the city occurrence."""

--- a/sentinela/extraction/ner.py
+++ b/sentinela/extraction/ner.py
@@ -1,0 +1,13 @@
+"""Protocols and helper structures for NER integration."""
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from .models import EntitySpan
+
+
+class NEREngine(Protocol):
+    """Interface for an entity recognition engine."""
+
+    def analyze(self, text: str) -> Iterable[EntitySpan]:
+        """Return entity spans detected in the provided text."""

--- a/sentinela/extraction/normalization.py
+++ b/sentinela/extraction/normalization.py
@@ -1,0 +1,151 @@
+"""Normalization helpers for the entity extraction pipeline."""
+from __future__ import annotations
+
+import re
+from typing import Set
+
+from .models import NormalizedPersonName
+
+_BOILERPLATE_PREFIXES = (
+    "leia também",
+    "leia ainda",
+    "crédito:",
+    "reportagem:",
+    "foto:",
+)
+
+_HONORIFIC_PATTERNS = (
+    r"\bdr\.?\b",
+    r"\bdra\.?\b",
+    r"\bdep\.?\b",
+    r"\bdeputad[ao]a?\b",
+    r"\bministr[ao]a?\b",
+    r"\bpresidente\b",
+    r"\bgovernador[ae]?\b",
+    r"\bprefeit[ao]a?\b",
+    r"\bvereador[ae]?\b",
+    r"\bsenador[ae]?\b",
+)
+
+_STATE_NAMES = {
+    "acre": "AC",
+    "alagoas": "AL",
+    "amapá": "AP",
+    "amazonas": "AM",
+    "bahia": "BA",
+    "ceará": "CE",
+    "distrito federal": "DF",
+    "espírito santo": "ES",
+    "goiás": "GO",
+    "maranhão": "MA",
+    "mato grosso": "MT",
+    "mato grosso do sul": "MS",
+    "minas gerais": "MG",
+    "pará": "PA",
+    "paraíba": "PB",
+    "paraná": "PR",
+    "pernambuco": "PE",
+    "piauí": "PI",
+    "rio de janeiro": "RJ",
+    "rio grande do norte": "RN",
+    "rio grande do sul": "RS",
+    "rondônia": "RO",
+    "roraima": "RR",
+    "santa catarina": "SC",
+    "são paulo": "SP",
+    "sergipe": "SE",
+    "tocantins": "TO",
+}
+
+_STATE_ABBREVIATIONS = set(_STATE_NAMES.values())
+
+_SENTENCE_REGEX = re.compile(r"[^.!?\n]+[.!?]?")
+_CONNECTORS = {"da", "de", "dos", "das", "do", "e"}
+
+
+def normalize_article_text(text: str) -> str:
+    """Clean boilerplate snippets and normalise whitespace."""
+
+    lines = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if any(line.lower().startswith(prefix) for prefix in _BOILERPLATE_PREFIXES):
+            continue
+        lines.append(line)
+    cleaned = "\n".join(lines)
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.strip()
+
+
+def _remove_titles(name: str) -> str:
+    pattern = re.compile("|".join(_HONORIFIC_PATTERNS), re.IGNORECASE)
+    without_titles = pattern.sub("", name)
+    without_titles = re.sub(r"(?i)^ex[\s-]+", "", without_titles)
+    without_titles = re.sub(r"^[^\wÀ-ÿ]+", "", without_titles)
+    return without_titles
+
+
+def _titlecase_word(word: str) -> str:
+    if not word:
+        return word
+    lowered = word.lower()
+    if word.isupper() and len(word) <= 3 and lowered not in _CONNECTORS:
+        return word.upper()
+    # Handle hyphenated names preserving accents
+    parts = []
+    for part in word.split("-"):
+        part_lower = part.lower()
+        if part_lower in _CONNECTORS:
+            parts.append(part_lower.capitalize())
+        else:
+            parts.append(part.capitalize())
+    return "-".join(parts)
+
+
+def normalize_person_name(surface: str) -> NormalizedPersonName:
+    """Return the canonical name and aliases for a surface form."""
+
+    name = surface.strip()
+    name = _remove_titles(name)
+    name = re.sub(r"\s+", " ", name).strip()
+    tokens = [_titlecase_word(token) for token in name.split(" ") if token]
+    canonical = " ".join(tokens)
+    aliases: Set[str] = set()
+    if canonical and canonical != surface.strip():
+        aliases.add(surface.strip())
+    return NormalizedPersonName(canonical_name=canonical, aliases=aliases)
+
+
+def find_sentence_containing(text: str, start: int, end: int) -> str:
+    """Return the sentence that contains the character span."""
+
+    for match in _SENTENCE_REGEX.finditer(text):
+        if match.start() <= start < match.end():
+            return match.group().strip()
+    return text.strip()
+
+
+def extract_state_mentions(text: str) -> Set[str]:
+    """Identify Brazilian state abbreviations present in the text."""
+
+    mentions: Set[str] = set()
+    lowered = text.lower()
+    for name, uf in _STATE_NAMES.items():
+        if name in lowered:
+            mentions.add(uf)
+    for uf in _STATE_ABBREVIATIONS:
+        pattern = rf"\b{uf}\b"
+        if re.search(pattern, text):
+            mentions.add(uf)
+    return mentions
+
+
+__all__ = [
+    "NormalizedPersonName",
+    "extract_state_mentions",
+    "find_sentence_containing",
+    "normalize_article_text",
+    "normalize_person_name",
+]

--- a/sentinela/extraction/service.py
+++ b/sentinela/extraction/service.py
@@ -1,0 +1,192 @@
+"""Main orchestration service for entity extraction."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, List, Tuple
+
+from .gazetteer import CityGazetteer, find_city_pattern_matches
+from .models import (
+    CityOccurrence,
+    EntitySpan,
+    NewsDocument,
+    PersonOccurrence,
+    ProcessedBatchResult,
+    ExtractionResultWriter,
+    NewsRepository,
+)
+from .ner import NEREngine
+from .normalization import (
+    extract_state_mentions,
+    find_sentence_containing,
+    normalize_article_text,
+    normalize_person_name,
+)
+
+
+_PERSON_LABELS = {"PERSON", "PER"}
+_CITY_LABELS = {"LOC", "LOCATION", "GPE", "CITY"}
+
+
+class EntityExtractionService:
+    """Coordinates the full pipeline of the entity extraction microservice."""
+
+    def __init__(
+        self,
+        *,
+        news_repository: NewsRepository,
+        result_writer: ExtractionResultWriter,
+        ner_engine: NEREngine,
+        gazetteer: CityGazetteer,
+        ner_version: str,
+        gazetteer_version: str,
+        batch_size: int = 500,
+    ) -> None:
+        self._news_repository = news_repository
+        self._result_writer = result_writer
+        self._ner_engine = ner_engine
+        self._gazetteer = gazetteer
+        self._ner_version = ner_version
+        self._gazetteer_version = gazetteer_version
+        self._batch_size = batch_size
+        self._log = logging.getLogger("sentinela.entity_extraction")
+
+    def process_next_batch(self) -> ProcessedBatchResult:
+        """Fetch and process the next batch of news awaiting extraction."""
+
+        batch = list(
+            self._news_repository.fetch_pending(
+                self._batch_size, self._ner_version, self._gazetteer_version
+            )
+        )
+        processed = 0
+        skipped_empty = 0
+        errors: List[Tuple[str, str]] = []
+
+        for document in batch:
+            try:
+                if not document.title and not document.body:
+                    skipped_empty += 1
+                    self._news_repository.mark_processed(
+                        document.url,
+                        self._ner_version,
+                        self._gazetteer_version,
+                        datetime.now(timezone.utc),
+                    )
+                    continue
+                self._process_document(document)
+                self._news_repository.mark_processed(
+                    document.url,
+                    self._ner_version,
+                    self._gazetteer_version,
+                    datetime.now(timezone.utc),
+                )
+                processed += 1
+            except Exception as exc:  # pragma: no cover - defensive logging
+                message = str(exc)
+                errors.append((document.url, message))
+                self._log.exception("Falha ao processar notícia %s", document.url)
+                self._news_repository.mark_error(document.url, message)
+
+        return ProcessedBatchResult(
+            processed=processed,
+            skipped_empty=skipped_empty,
+            errors=tuple(errors),
+        )
+
+    def _process_document(self, document: NewsDocument) -> None:
+        combined = document.combined_text()
+        normalized_text = normalize_article_text(combined)
+        entities = list(self._ner_engine.analyze(normalized_text))
+        state_mentions = extract_state_mentions(normalized_text)
+
+        person_entities = [e for e in entities if e.label in _PERSON_LABELS]
+        city_entities = [e for e in entities if e.label in _CITY_LABELS]
+
+        person_cache: Dict[str, str] = {}
+        for entity in person_entities:
+            normalized = normalize_person_name(entity.text)
+            if not normalized.canonical_name:
+                continue
+            person_id = person_cache.get(normalized.canonical_name)
+            if not person_id:
+                person_id = self._result_writer.ensure_person(
+                    normalized.canonical_name, normalized.aliases
+                )
+                person_cache[normalized.canonical_name] = person_id
+            sentence = find_sentence_containing(
+                normalized_text, entity.start, entity.end
+            )
+            occurrence = PersonOccurrence(
+                person_id=person_id,
+                canonical_name=normalized.canonical_name,
+                surface=entity.text,
+                start=entity.start,
+                end=entity.end,
+                sentence=sentence,
+                method=entity.method,
+                confidence=entity.score,
+            )
+            self._result_writer.record_person_occurrence(document.url, occurrence)
+
+        # Augment city entities with deterministic pattern matches
+        seen_spans: set[Tuple[int, int]] = {(e.start, e.end) for e in city_entities}
+        for surface, span, uf_surface in find_city_pattern_matches(normalized_text):
+            if span in seen_spans:
+                continue
+            city_entities.append(
+                EntitySpan(
+                    label="CITY_PATTERN",
+                    text=surface,
+                    start=span[0],
+                    end=span[1],
+                    score=0.9,
+                    method="pattern",
+                )
+            )
+            seen_spans.add(span)
+
+        for entity in city_entities:
+            city_name, uf_surface = _split_city_surface(entity.text)
+            resolution = self._gazetteer.resolve(
+                city_name,
+                uf_surface=uf_surface,
+                context_states=state_mentions,
+            )
+            sentence = find_sentence_containing(
+                normalized_text, entity.start, entity.end
+            )
+            occurrence = CityOccurrence(
+                city_id=resolution.city_id,
+                surface=entity.text,
+                start=entity.start,
+                end=entity.end,
+                sentence=sentence,
+                status=resolution.status,
+                uf_surface=uf_surface,
+                method=entity.method,
+                confidence=(
+                    min(entity.score, resolution.confidence)
+                    if resolution.city_id is None
+                    else entity.score
+                ),
+                candidates=resolution.candidates,
+            )
+            self._result_writer.record_city_occurrence(document.url, occurrence)
+
+
+def _split_city_surface(surface: str) -> tuple[str, str | None]:
+    """Extract the canonical city name and optional UF from a surface form."""
+
+    text = surface.strip()
+    for separator in ("-", "/"):
+        if separator in text:
+            parts = [part.strip() for part in text.split(separator) if part.strip()]
+            if len(parts) >= 2 and parts[-1].isalpha() and len(parts[-1]) == 2:
+                uf = parts[-1].upper()
+                name = separator.join(parts[:-1]).strip()
+                return name, uf
+    return text, None
+
+
+__all__ = ["EntityExtractionService"]

--- a/tests/test_entity_extraction_service.py
+++ b/tests/test_entity_extraction_service.py
@@ -1,0 +1,109 @@
+from datetime import datetime, timezone
+from typing import Iterable, List
+
+from sentinela.extraction import (
+    CityGazetteer,
+    CityRecord,
+    EntityExtractionService,
+    EntitySpan,
+    NewsDocument,
+)
+from sentinela.extraction.models import (
+    CityOccurrence,
+    ExtractionResultWriter,
+    NewsRepository,
+    PersonOccurrence,
+)
+from sentinela.extraction.ner import NEREngine
+
+
+class FakeNewsRepository(NewsRepository):
+    def __init__(self, documents: Iterable[NewsDocument]):
+        self._documents = list(documents)
+        self.processed: List[str] = []
+        self.errors: List[str] = []
+
+    def fetch_pending(self, batch_size: int, ner_version: str, gazetteer_version: str):
+        return list(self._documents)
+
+    def mark_processed(self, url: str, ner_version: str, gazetteer_version: str, processed_at):
+        self.processed.append(url)
+
+    def mark_error(self, url: str, message: str) -> None:
+        self.errors.append(url)
+
+
+class FakeNER(NEREngine):
+    def __init__(self, entities: Iterable[EntitySpan]):
+        self.entities = list(entities)
+
+    def analyze(self, text: str):
+        return list(self.entities)
+
+
+class FakeResultWriter(ExtractionResultWriter):
+    def __init__(self):
+        self.people: List[PersonOccurrence] = []
+        self.cities: List[CityOccurrence] = []
+        self.counter = 0
+
+    def ensure_person(self, canonical_name: str, aliases: set[str]) -> str:
+        self.counter += 1
+        return str(self.counter)
+
+    def record_person_occurrence(self, url: str, occurrence: PersonOccurrence) -> None:
+        self.people.append(occurrence)
+
+    def record_city_occurrence(self, url: str, occurrence: CityOccurrence) -> None:
+        self.cities.append(occurrence)
+
+
+def test_entity_extraction_service_processes_people_and_cities():
+    document = NewsDocument(
+        url="http://example.com",
+        title="PREFEITO DE RECIFE anuncia obras",
+        body="O prefeito de Recife-PE, João da Silva, falou com Maria Souza.",
+        published_at=datetime.now(timezone.utc),
+        source="test",
+    )
+    normalized_text = " ".join(document.combined_text().split())
+    joao_start = normalized_text.index("João")
+    maria_start = normalized_text.index("Maria")
+    recife_start = normalized_text.index("Recife")
+    ner_entities = [
+        EntitySpan(label="PERSON", text="João da Silva", start=joao_start, end=joao_start + 13, score=0.92),
+        EntitySpan(label="PERSON", text="Maria Souza", start=maria_start, end=maria_start + 11, score=0.88),
+        EntitySpan(label="GPE", text="Recife", start=recife_start, end=recife_start + 6, score=0.75),
+    ]
+    gazetteer = CityGazetteer(
+        [
+            CityRecord(id="1", name="Recife", uf="PE", alt_names=("Recife",)),
+            CityRecord(id="2", name="Recife", uf="PB"),
+        ]
+    )
+    repository = FakeNewsRepository([document])
+    result_writer = FakeResultWriter()
+    service = EntityExtractionService(
+        news_repository=repository,
+        result_writer=result_writer,
+        ner_engine=FakeNER(ner_entities),
+        gazetteer=gazetteer,
+        ner_version="1",
+        gazetteer_version="1",
+        batch_size=10,
+    )
+
+    result = service.process_next_batch()
+
+    assert result.processed == 1
+    assert not result.errors
+    assert repository.processed == [document.url]
+    assert len(result_writer.people) == 2
+    assert {p.canonical_name for p in result_writer.people} == {
+        "João Da Silva",
+        "Maria Souza",
+    }
+    assert len(result_writer.cities) >= 1
+    city_occurrence = result_writer.cities[0]
+    assert city_occurrence.status in {"resolved", "ambiguous"}
+    assert city_occurrence.uf_surface in {"PE", None}

--- a/tests/test_extraction_gazetteer.py
+++ b/tests/test_extraction_gazetteer.py
@@ -1,0 +1,32 @@
+from sentinela.extraction.gazetteer import CityGazetteer, CityRecord
+
+
+def build_gazetteer():
+    records = [
+        CityRecord(id="1", name="São João", uf="PE", alt_names=("Sao Joao",)),
+        CityRecord(id="2", name="São João", uf="SP"),
+        CityRecord(id="3", name="Recife", uf="PE", alt_names=("Recife", "Recife-PE")),
+    ]
+    return CityGazetteer(records)
+
+
+def test_gazetteer_resolves_with_context():
+    gazetteer = build_gazetteer()
+    resolution = gazetteer.resolve("São João", uf_surface=None, context_states={"PE"})
+    assert resolution.status == "resolved"
+    assert resolution.city_id == "1"
+
+
+def test_gazetteer_marks_ambiguous_without_context():
+    gazetteer = build_gazetteer()
+    resolution = gazetteer.resolve("São João", uf_surface=None, context_states=set())
+    assert resolution.status == "ambiguous"
+    assert resolution.city_id is None
+    assert len(resolution.candidates) == 2
+
+
+def test_gazetteer_returns_foreign_when_not_found():
+    gazetteer = build_gazetteer()
+    resolution = gazetteer.resolve("Springfield", uf_surface=None, context_states=None)
+    assert resolution.status == "foreign"
+    assert resolution.city_id is None

--- a/tests/test_extraction_normalization.py
+++ b/tests/test_extraction_normalization.py
@@ -1,0 +1,30 @@
+from sentinela.extraction.normalization import (
+    extract_state_mentions,
+    find_sentence_containing,
+    normalize_article_text,
+    normalize_person_name,
+)
+
+
+def test_normalize_article_text_removes_boilerplate():
+    text = "Leia também: algo\nCorpo da matéria\nCrédito: foto"
+    assert normalize_article_text(text) == "Corpo da matéria"
+
+
+def test_normalize_person_name_removes_titles_and_titlecases():
+    result = normalize_person_name("Dr. JOÃO DA SILVA")
+    assert result.canonical_name == "João Da Silva"
+    assert "Dr. JOÃO DA SILVA" in result.aliases
+
+
+def test_find_sentence_containing_returns_expected_sentence():
+    text = "Primeira frase. Segunda frase com João." \
+        " Terceira frase."
+    sentence = find_sentence_containing(text, text.index("João"), text.index("João") + 4)
+    assert sentence == "Segunda frase com João."
+
+
+def test_extract_state_mentions_handles_names_and_abbreviations():
+    text = "O governador de Pernambuco visitou Recife - PE."
+    mentions = extract_state_mentions(text)
+    assert mentions == {"PE"}


### PR DESCRIPTION
## Summary
- add a dedicated `sentinela.extraction` package with models, normalization utilities, gazetteer matching and orchestration service for the people/city pipeline
- cover normalization, gazetteer resolution and pipeline orchestration with unit tests that exercise the new components

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cea4d185e8832bb5158143c560fa91