### PR TITLE
Refine service containers by domain

### DIFF
--- a/sentinela/__init__.py
+++ b/sentinela/__init__.py
@@ -1,6 +1,8 @@
 """Sentinela - coletor modular de notícias."""
 from .application.services import NewsCollectorService, PortalRegistrationService
 from .container import build_container
+from .services.news import build_news_container
+from .services.portals import build_portals_container
 from .domain.entities import Article, Portal, PortalSelectors, Selector
 
 __all__ = [
@@ -11,4 +13,6 @@ __all__ = [
     "NewsCollectorService",
     "PortalRegistrationService",
     "build_container",
+    "build_news_container",
+    "build_portals_container",
 ]

--- a/sentinela/services/__init__.py
+++ b/sentinela/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service containers for application domains."""

--- a/sentinela/services/news/__init__.py
+++ b/sentinela/services/news/__init__.py
@@ -1,0 +1,5 @@
+"""News collection service dependency container."""
+
+from .container import NewsContainer, build_news_container
+
+__all__ = ["NewsContainer", "build_news_container"]

--- a/sentinela/services/news/container.py
+++ b/sentinela/services/news/container.py
@@ -1,0 +1,48 @@
+"""Dependency container for news collection services."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentinela.application.services import NewsCollectorService
+from sentinela.infrastructure.database import MongoClientFactory
+from sentinela.infrastructure.repositories import (
+    MongoArticleRepository,
+    MongoPortalRepository,
+)
+from sentinela.infrastructure.scraper import RequestsSoupScraper
+
+
+@dataclass
+class NewsContainer:
+    """Container exposing news collection service dependencies."""
+
+    portal_repository: MongoPortalRepository
+    article_repository: MongoArticleRepository
+    scraper: RequestsSoupScraper
+    collector_service: NewsCollectorService
+
+
+def build_news_container(
+    factory: MongoClientFactory | None = None,
+) -> NewsContainer:
+    """Build the news collection service container."""
+
+    factory = factory or MongoClientFactory()
+    database = factory.get_database()
+
+    portal_repository = MongoPortalRepository(database["portals"])
+    article_repository = MongoArticleRepository(database["articles"])
+    scraper = RequestsSoupScraper()
+
+    collector_service = NewsCollectorService(
+        portal_repository=portal_repository,
+        article_repository=article_repository,
+        scraper=scraper,
+    )
+
+    return NewsContainer(
+        portal_repository=portal_repository,
+        article_repository=article_repository,
+        scraper=scraper,
+        collector_service=collector_service,
+    )

--- a/sentinela/services/portals/__init__.py
+++ b/sentinela/services/portals/__init__.py
@@ -1,0 +1,5 @@
+"""Portal service dependency container."""
+
+from .container import PortalsContainer, build_portals_container
+
+__all__ = ["PortalsContainer", "build_portals_container"]

--- a/sentinela/services/portals/container.py
+++ b/sentinela/services/portals/container.py
@@ -1,0 +1,33 @@
+"""Dependency container for portal-related services."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentinela.application.services import PortalRegistrationService
+from sentinela.infrastructure.database import MongoClientFactory
+from sentinela.infrastructure.repositories import MongoPortalRepository
+
+
+@dataclass
+class PortalsContainer:
+    """Container exposing portal service dependencies."""
+
+    portal_repository: MongoPortalRepository
+    portal_service: PortalRegistrationService
+
+
+def build_portals_container(
+    factory: MongoClientFactory | None = None,
+) -> PortalsContainer:
+    """Build the portal service container."""
+
+    factory = factory or MongoClientFactory()
+    database = factory.get_database()
+
+    portal_repository = MongoPortalRepository(database["portals"])
+    portal_service = PortalRegistrationService(portal_repository)
+
+    return PortalsContainer(
+        portal_repository=portal_repository,
+        portal_service=portal_service,
+    )


### PR DESCRIPTION
## Summary
- add dedicated portal and news containers under sentinela.services
- update CLI/API to build domain-specific containers while keeping legacy shim
- document the new container structure and exports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d181341780832b98a70c3bdaa60be7