### PR TITLE
Split API into dedicated services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,7 @@ dev = [
 
 [project.scripts]
 sentinela-api = "sentinela.api:run"
+sentinela-portal-api = "sentinela.services.portals.api:run"
+sentinela-news-api = "sentinela.services.news.api:run"
+sentinela-publications-api = "sentinela.services.publications.api:run"
 sentinela-cli = "sentinela.cli:main"

--- a/sentinela/api.py
+++ b/sentinela/api.py
@@ -1,270 +1,55 @@
-"""REST API entrypoint for Sentinela."""
+"""REST API entrypoint aggregating Sentinela services."""
 from __future__ import annotations
 
-import asyncio
-import json
-from datetime import date
-from typing import Any, Dict, Iterable
+import os
 
 import uvicorn
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request
-from pydantic import BaseModel, Field
-from sse_starlette.sse import EventSourceResponse
+from fastapi import FastAPI
 
-from sentinela.domain.entities import Article, Portal, PortalSelectors, Selector
 from sentinela.services.news import build_news_container
+from sentinela.services.news.api import include_routes as include_news_routes
 from sentinela.services.portals import build_portals_container
-
-
-class SelectorPayload(BaseModel):
-    """Payload representation of a selector configuration."""
-
-    query: str
-    attribute: str | None = None
-
-    def to_domain(self) -> Selector:
-        return Selector(query=self.query, attribute=self.attribute)
-
-
-class PortalSelectorsPayload(BaseModel):
-    """Payload representation of selectors for a portal."""
-
-    listing_article: SelectorPayload
-    listing_title: SelectorPayload
-    listing_url: SelectorPayload
-    article_content: SelectorPayload
-    article_date: SelectorPayload
-    listing_summary: SelectorPayload | None = None
-
-    def to_domain(self) -> PortalSelectors:
-        return PortalSelectors(
-            listing_article=self.listing_article.to_domain(),
-            listing_title=self.listing_title.to_domain(),
-            listing_url=self.listing_url.to_domain(),
-            article_content=self.article_content.to_domain(),
-            article_date=self.article_date.to_domain(),
-            listing_summary=self.listing_summary.to_domain()
-            if self.listing_summary
-            else None,
-        )
-
-
-class PortalPayload(BaseModel):
-    """Payload representation of a portal registration request."""
-
-    name: str
-    base_url: str
-    listing_path_template: str
-    selectors: PortalSelectorsPayload
-    headers: Dict[str, str] = Field(default_factory=dict)
-    date_format: str = "%Y-%m-%d"
-
-    def to_domain(self) -> Portal:
-        return Portal(
-            name=self.name,
-            base_url=self.base_url,
-            listing_path_template=self.listing_path_template,
-            selectors=self.selectors.to_domain(),
-            headers=self.headers,
-            date_format=self.date_format,
-        )
-
-
-class PortalResponse(BaseModel):
-    """Representation of a portal returned by the API."""
-
-    name: str
-    base_url: str
-    listing_path_template: str
-    selectors: Dict[str, Any]
-    headers: Dict[str, str]
-    date_format: str
-
-
-class CollectRequest(BaseModel):
-    """Parameters to trigger article collection."""
-
-    portal: str
-    start_date: date
-    end_date: date | None = None
-
-
-class ArticleResponse(BaseModel):
-    """Representation of an article returned by the API."""
-
-    portal: str
-    title: str
-    url: str
-    content: str
-    published_at: str
-    summary: str | None = None
-
-
-class CollectResponse(BaseModel):
-    """Response returned after collecting articles."""
-
-    portal: str
-    collected: int
-    articles: list[ArticleResponse]
+from sentinela.services.portals.api import (
+    configure_cors as configure_default_cors,
+    include_routes as include_portals_routes,
+)
+from sentinela.services.publications import build_publications_container
+from sentinela.services.publications.api import include_routes as include_publications_routes
 
 
 def create_app() -> FastAPI:
-    """Create the FastAPI application with all routes configured."""
+    """Create the FastAPI application with all service routes configured."""
 
     portals_container = build_portals_container()
     news_container = build_news_container()
-    app = FastAPI(title="Sentinela API", version="1.0.0")
+    publications_container = build_publications_container()
 
-    def map_portal_response(portal: Portal) -> PortalResponse:
-        selectors = portal.selectors
-        selectors_payload: Dict[str, Any] = {
-            "listing_article": selector_to_dict(selectors.listing_article),
-            "listing_title": selector_to_dict(selectors.listing_title),
-            "listing_url": selector_to_dict(selectors.listing_url),
-            "article_content": selector_to_dict(selectors.article_content),
-            "article_date": selector_to_dict(selectors.article_date),
-        }
-        if selectors.listing_summary:
-            selectors_payload["listing_summary"] = selector_to_dict(
-                selectors.listing_summary
-            )
-        return PortalResponse(
-            name=portal.name,
-            base_url=portal.base_url,
-            listing_path_template=portal.listing_path_template,
-            selectors=selectors_payload,
-            headers=portal.headers,
-            date_format=portal.date_format,
-        )
-
-    def map_article_response(article: Article) -> ArticleResponse:
-        return ArticleResponse(
-            portal=article.portal_name,
-            title=article.title,
-            url=article.url,
-            content=article.content,
-            published_at=article.published_at.isoformat(),
-            summary=article.summary,
-        )
-
-    def handle_value_error(exc: ValueError) -> HTTPException:
-        detail = str(exc)
-        status = 404 if "not found" in detail.lower() else 400
-        return HTTPException(status_code=status, detail=detail)
-
-    @app.post("/portals", response_model=PortalResponse, status_code=201)
-    def register_portal(payload: PortalPayload) -> PortalResponse:
-        try:
-            portal = payload.to_domain()
-            portals_container.portal_service.register(portal)
-        except ValueError as exc:  # Portal already exists
-            raise handle_value_error(exc)
-        return map_portal_response(portal)
-
-    @app.get("/portals", response_model=list[PortalResponse])
-    def list_portals() -> Iterable[PortalResponse]:
-        return [
-            map_portal_response(portal)
-            for portal in portals_container.portal_service.list_portals()
-        ]
-
-    @app.post("/collect", response_model=CollectResponse)
-    def collect_articles(request: CollectRequest) -> CollectResponse:
-        try:
-            end_date = request.end_date or request.start_date
-            articles = news_container.collector_service.collect(
-                request.portal, request.start_date, end_date
-            )
-        except ValueError as exc:
-            raise handle_value_error(exc)
-
-        return CollectResponse(
-            portal=request.portal,
-            collected=len(articles),
-            articles=[map_article_response(article) for article in articles],
-        )
-
-    @app.post("/collect/stream")
-    async def collect_articles_stream(
-        request: Request, payload: CollectRequest
-    ) -> EventSourceResponse:
-        loop = asyncio.get_running_loop()
-        queue: asyncio.Queue[dict[str, str] | None] = asyncio.Queue()
-
-        def push(event: str, data: str) -> None:
-            loop.call_soon_threadsafe(queue.put_nowait, {"event": event, "data": data})
-
-        def finish() -> None:
-            loop.call_soon_threadsafe(queue.put_nowait, None)
-
-        def status_callback(message: str) -> None:
-            push("log", message)
-
-        async def run_collection() -> None:
-            try:
-                end_date = payload.end_date or payload.start_date
-                articles = await loop.run_in_executor(
-                    None,
-                    lambda: news_container.collector_service.collect(
-                        payload.portal,
-                        payload.start_date,
-                        end_date,
-                        status_callback=status_callback,
-                    ),
-                )
-                response = CollectResponse(
-                    portal=payload.portal,
-                    collected=len(articles),
-                    articles=[map_article_response(article) for article in articles],
-                )
-                push("summary", json.dumps(response.model_dump()))
-            except ValueError as exc:
-                push("error", str(exc))
-            except Exception:
-                push(
-                    "error",
-                    "Erro inesperado durante a coleta de artigos. Verifique os logs do servidor.",
-                )
-            finally:
-                finish()
-
-        task = asyncio.create_task(run_collection())
-
-        async def event_generator():
-            try:
-                while True:
-                    if await request.is_disconnected():
-                        task.cancel()
-                        break
-                    event = await queue.get()
-                    if event is None:
-                        break
-                    yield event
-            finally:
-                if not task.done():
-                    task.cancel()
-
-        return EventSourceResponse(event_generator())
-
-    @app.get("/articles", response_model=list[ArticleResponse])
-    def list_articles(portal: str, start_date: date, end_date: date) -> Iterable[ArticleResponse]:
-        articles = news_container.collector_service.list_articles(
-            portal, start_date, end_date
-        )
-        return [map_article_response(article) for article in articles]
-
+    app = FastAPI(
+        title="Sentinela API",
+        version="1.0.0",
+        description=(
+            "Agrega as operações de cadastro de portais, coleta de notícias e "
+            "consulta de publicações em uma única aplicação."
+        ),
+    )
+    configure_default_cors(app)
+    include_portals_routes(app, portals_container)
+    include_news_routes(app, news_container)
+    include_publications_routes(app, publications_container)
     return app
 
 
-def selector_to_dict(selector: Selector) -> Dict[str, Any]:
-    return {"query": selector.query, "attribute": selector.attribute}
-
-
 def run() -> None:
-    """Run the API using Uvicorn."""
+    """Run the aggregated API using Uvicorn."""
+
     load_dotenv()
-    uvicorn.run("sentinela.api:create_app", host="0.0.0.0", port=8000, factory=True)
+    uvicorn.run(
+        "sentinela.api:create_app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8000")),
+        factory=True,
+    )
 
 
 __all__ = ["create_app", "run"]

--- a/sentinela/application/services.py
+++ b/sentinela/application/services.py
@@ -8,7 +8,11 @@ import logging
 import time
 
 from sentinela.domain.entities import Article, Portal
-from sentinela.domain.repositories import ArticleRepository, PortalRepository
+from sentinela.domain.repositories import (
+    ArticleReadRepository,
+    ArticleRepository,
+    PortalRepository,
+)
 from sentinela.infrastructure.scraper import Scraper
 
 
@@ -99,6 +103,7 @@ class NewsCollectorService:
         start_dt = datetime.combine(start_date, datetime.min.time())
         end_dt = datetime.combine(end_date, datetime.max.time())
         return self._article_repository.list_by_period(portal_name, start_dt, end_dt)
+
 
     def collect_all_for_portal(
         self,
@@ -233,3 +238,17 @@ class NewsCollectorService:
             )
         )
         return all_new
+
+
+class ArticleQueryService:
+    """Provides read-only access to collected articles."""
+
+    def __init__(self, repository: ArticleReadRepository) -> None:
+        self._repository = repository
+
+    def list_articles(
+        self, portal_name: str, start_date: date, end_date: date
+    ) -> Iterable[Article]:
+        start_dt = datetime.combine(start_date, datetime.min.time())
+        end_dt = datetime.combine(end_date, datetime.max.time())
+        return self._repository.list_by_period(portal_name, start_dt, end_dt)

--- a/sentinela/domain/repositories.py
+++ b/sentinela/domain/repositories.py
@@ -40,3 +40,13 @@ class ArticleRepository(ABC):
         self, portal_name: str, start: datetime, end: datetime
     ) -> Iterable[Article]:
         """List the articles that match the given period."""
+
+
+class ArticleReadRepository(ABC):
+    """Read-only access to persisted articles."""
+
+    @abstractmethod
+    def list_by_period(
+        self, portal_name: str, start: datetime, end: datetime
+    ) -> Iterable[Article]:
+        """List the articles that match the given period."""

--- a/sentinela/services/news/api.py
+++ b/sentinela/services/news/api.py
@@ -1,0 +1,194 @@
+"""FastAPI application exposing article collection endpoints."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import date
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse
+
+from sentinela.domain.entities import Article
+from sentinela.services.news import NewsContainer, build_news_container
+
+
+class CollectRequest(BaseModel):
+    """Parameters to trigger article collection."""
+
+    portal: str
+    start_date: date
+    end_date: date | None = None
+
+
+class ArticleResponse(BaseModel):
+    """Representation of an article returned by the API."""
+
+    portal: str
+    title: str
+    url: str
+    content: str
+    published_at: str
+    summary: str | None = None
+
+
+class CollectResponse(BaseModel):
+    """Response returned after collecting articles."""
+
+    portal: str
+    collected: int
+    articles: list[ArticleResponse]
+
+
+def configure_cors(app: FastAPI) -> None:
+    """Apply the default CORS configuration used by the services."""
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+def include_routes(app: FastAPI, container: NewsContainer, *, prefix: str = "") -> None:
+    """Register news collection routes on a FastAPI application."""
+
+    router = APIRouter(prefix=prefix, tags=["Coleta de Notícias"])
+
+    def map_article_response(article: Article) -> ArticleResponse:
+        return ArticleResponse(
+            portal=article.portal_name,
+            title=article.title,
+            url=article.url,
+            content=article.content,
+            published_at=article.published_at.isoformat(),
+            summary=article.summary,
+        )
+
+    def handle_value_error(exc: ValueError) -> HTTPException:
+        detail = str(exc)
+        status = 404 if "not found" in detail.lower() else 400
+        return HTTPException(status_code=status, detail=detail)
+
+    @router.post("/collect", response_model=CollectResponse)
+    def collect_articles(request: CollectRequest) -> CollectResponse:
+        try:
+            end_date = request.end_date or request.start_date
+            articles = container.collector_service.collect(
+                request.portal, request.start_date, end_date
+            )
+        except ValueError as exc:
+            raise handle_value_error(exc)
+
+        return CollectResponse(
+            portal=request.portal,
+            collected=len(articles),
+            articles=[map_article_response(article) for article in articles],
+        )
+
+    @router.post("/collect/stream")
+    async def collect_articles_stream(
+        request: Request, payload: CollectRequest
+    ) -> EventSourceResponse:
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[dict[str, str] | None] = asyncio.Queue()
+
+        def push(event: str, data: str) -> None:
+            loop.call_soon_threadsafe(queue.put_nowait, {"event": event, "data": data})
+
+        def finish() -> None:
+            loop.call_soon_threadsafe(queue.put_nowait, None)
+
+        def status_callback(message: str) -> None:
+            push("log", message)
+
+        async def run_collection() -> None:
+            try:
+                end_date = payload.end_date or payload.start_date
+                articles = await loop.run_in_executor(
+                    None,
+                    lambda: container.collector_service.collect(
+                        payload.portal,
+                        payload.start_date,
+                        end_date,
+                        status_callback=status_callback,
+                    ),
+                )
+                response = CollectResponse(
+                    portal=payload.portal,
+                    collected=len(articles),
+                    articles=[map_article_response(article) for article in articles],
+                )
+                push("summary", json.dumps(response.model_dump()))
+            except ValueError as exc:
+                push("error", str(exc))
+            except Exception:  # pragma: no cover - defensive path
+                push(
+                    "error",
+                    "Erro inesperado durante a coleta de artigos. Verifique os logs do servidor.",
+                )
+            finally:
+                finish()
+
+        task = asyncio.create_task(run_collection())
+
+        async def event_generator():
+            try:
+                while True:
+                    if await request.is_disconnected():
+                        task.cancel()
+                        break
+                    event = await queue.get()
+                    if event is None:
+                        break
+                    yield event
+            finally:
+                if not task.done():
+                    task.cancel()
+
+        return EventSourceResponse(event_generator())
+
+    app.include_router(router)
+
+
+def create_app() -> FastAPI:
+    """Create the FastAPI application with news collection routes."""
+
+    container = build_news_container()
+    app = FastAPI(
+        title="Sentinela News API",
+        version="1.0.0",
+        description="Coleta e monitoramento de notícias em portais cadastrados.",
+    )
+    configure_cors(app)
+    include_routes(app, container)
+    return app
+
+
+def run() -> None:
+    """Run the news API using Uvicorn."""
+
+    load_dotenv()
+    uvicorn.run(
+        "sentinela.services.news.api:create_app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8000")),
+        factory=True,
+    )
+
+
+__all__ = [
+    "ArticleResponse",
+    "CollectRequest",
+    "CollectResponse",
+    "create_app",
+    "configure_cors",
+    "include_routes",
+    "run",
+]

--- a/sentinela/services/portals/api.py
+++ b/sentinela/services/portals/api.py
@@ -1,0 +1,186 @@
+"""FastAPI application exposing portal management endpoints."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterable
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from sentinela.domain.entities import Portal, PortalSelectors, Selector
+from sentinela.services.portals import PortalsContainer, build_portals_container
+
+
+class SelectorPayload(BaseModel):
+    """Payload representation of a selector configuration."""
+
+    query: str
+    attribute: str | None = None
+
+    def to_domain(self) -> Selector:
+        return Selector(query=self.query, attribute=self.attribute)
+
+
+class PortalSelectorsPayload(BaseModel):
+    """Payload representation of selectors for a portal."""
+
+    listing_article: SelectorPayload
+    listing_title: SelectorPayload
+    listing_url: SelectorPayload
+    article_content: SelectorPayload
+    article_date: SelectorPayload
+    listing_summary: SelectorPayload | None = None
+
+    def to_domain(self) -> PortalSelectors:
+        return PortalSelectors(
+            listing_article=self.listing_article.to_domain(),
+            listing_title=self.listing_title.to_domain(),
+            listing_url=self.listing_url.to_domain(),
+            article_content=self.article_content.to_domain(),
+            article_date=self.article_date.to_domain(),
+            listing_summary=self.listing_summary.to_domain()
+            if self.listing_summary
+            else None,
+        )
+
+
+class PortalPayload(BaseModel):
+    """Payload representation of a portal registration request."""
+
+    name: str
+    base_url: str
+    listing_path_template: str
+    selectors: PortalSelectorsPayload
+    headers: Dict[str, str] = Field(default_factory=dict)
+    date_format: str = "%Y-%m-%d"
+
+    def to_domain(self) -> Portal:
+        return Portal(
+            name=self.name,
+            base_url=self.base_url,
+            listing_path_template=self.listing_path_template,
+            selectors=self.selectors.to_domain(),
+            headers=self.headers,
+            date_format=self.date_format,
+        )
+
+
+class PortalResponse(BaseModel):
+    """Representation of a portal returned by the API."""
+
+    name: str
+    base_url: str
+    listing_path_template: str
+    selectors: Dict[str, Any]
+    headers: Dict[str, str]
+    date_format: str
+
+
+def configure_cors(app: FastAPI) -> None:
+    """Apply the default CORS configuration used by the services."""
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+def include_routes(
+    app: FastAPI, container: PortalsContainer, *, prefix: str = ""
+) -> None:
+    """Register portal routes on a FastAPI application."""
+
+    router = APIRouter(prefix=prefix, tags=["Portais"])
+
+    def map_portal_response(portal: Portal) -> PortalResponse:
+        selectors = portal.selectors
+        selectors_payload: Dict[str, Any] = {
+            "listing_article": selector_to_dict(selectors.listing_article),
+            "listing_title": selector_to_dict(selectors.listing_title),
+            "listing_url": selector_to_dict(selectors.listing_url),
+            "article_content": selector_to_dict(selectors.article_content),
+            "article_date": selector_to_dict(selectors.article_date),
+        }
+        if selectors.listing_summary:
+            selectors_payload["listing_summary"] = selector_to_dict(
+                selectors.listing_summary
+            )
+        return PortalResponse(
+            name=portal.name,
+            base_url=portal.base_url,
+            listing_path_template=portal.listing_path_template,
+            selectors=selectors_payload,
+            headers=portal.headers,
+            date_format=portal.date_format,
+        )
+
+    def handle_value_error(exc: ValueError) -> HTTPException:
+        detail = str(exc)
+        status = 404 if "not found" in detail.lower() else 400
+        return HTTPException(status_code=status, detail=detail)
+
+    @router.post("/portals", response_model=PortalResponse, status_code=201)
+    def register_portal(payload: PortalPayload) -> PortalResponse:
+        try:
+            portal = payload.to_domain()
+            container.portal_service.register(portal)
+        except ValueError as exc:  # Portal already exists
+            raise handle_value_error(exc)
+        return map_portal_response(portal)
+
+    @router.get("/portals", response_model=list[PortalResponse])
+    def list_portals() -> Iterable[PortalResponse]:
+        return [
+            map_portal_response(portal)
+            for portal in container.portal_service.list_portals()
+        ]
+
+    app.include_router(router)
+
+
+def create_app() -> FastAPI:
+    """Create the FastAPI application with portal routes configured."""
+
+    container = build_portals_container()
+    app = FastAPI(
+        title="Sentinela Portals API",
+        version="1.0.0",
+        description="Cadastro e consulta de portais monitorados.",
+    )
+    configure_cors(app)
+    include_routes(app, container)
+    return app
+
+
+def selector_to_dict(selector: Selector) -> Dict[str, Any]:
+    """Serialize a selector to a dictionary representation."""
+
+    return {"query": selector.query, "attribute": selector.attribute}
+
+
+def run() -> None:
+    """Run the portals API using Uvicorn."""
+
+    load_dotenv()
+    uvicorn.run(
+        "sentinela.services.portals.api:create_app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8000")),
+        factory=True,
+    )
+
+
+__all__ = [
+    "create_app",
+    "configure_cors",
+    "include_routes",
+    "PortalPayload",
+    "PortalResponse",
+    "run",
+]

--- a/sentinela/services/publications/__init__.py
+++ b/sentinela/services/publications/__init__.py
@@ -1,0 +1,5 @@
+"""Publications service dependency container."""
+
+from .container import PublicationsContainer, build_publications_container
+
+__all__ = ["PublicationsContainer", "build_publications_container"]

--- a/sentinela/services/publications/api.py
+++ b/sentinela/services/publications/api.py
@@ -1,0 +1,106 @@
+"""FastAPI application exposing publication read endpoints."""
+from __future__ import annotations
+
+import os
+from datetime import date
+from typing import Iterable
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from sentinela.domain.entities import Article
+from sentinela.services.publications import (
+    PublicationsContainer,
+    build_publications_container,
+)
+
+
+class ArticleResponse(BaseModel):
+    """Representation of an article returned by the API."""
+
+    portal: str
+    title: str
+    url: str
+    content: str
+    published_at: str
+    summary: str | None = None
+
+
+def configure_cors(app: FastAPI) -> None:
+    """Apply the default CORS configuration used by the services."""
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+def include_routes(
+    app: FastAPI, container: PublicationsContainer, *, prefix: str = ""
+) -> None:
+    """Register publication routes on a FastAPI application."""
+
+    router = APIRouter(prefix=prefix, tags=["Publicações"])
+
+    def map_article_response(article: Article) -> ArticleResponse:
+        return ArticleResponse(
+            portal=article.portal_name,
+            title=article.title,
+            url=article.url,
+            content=article.content,
+            published_at=article.published_at.isoformat(),
+            summary=article.summary,
+        )
+
+    @router.get("/articles", response_model=list[ArticleResponse])
+    def list_articles(portal: str, start_date: date, end_date: date) -> Iterable[ArticleResponse]:
+        if start_date > end_date:
+            raise HTTPException(
+                status_code=400,
+                detail="start_date deve ser anterior ou igual a end_date",
+            )
+        articles = container.query_service.list_articles(portal, start_date, end_date)
+        return [map_article_response(article) for article in articles]
+
+    app.include_router(router)
+
+
+def create_app() -> FastAPI:
+    """Create the FastAPI application with publication routes configured."""
+
+    container = build_publications_container()
+    app = FastAPI(
+        title="Sentinela Publications API",
+        version="1.0.0",
+        description="Consulta de artigos coletados pelos serviços do Sentinela.",
+    )
+    configure_cors(app)
+    include_routes(app, container)
+    return app
+
+
+def run() -> None:
+    """Run the publications API using Uvicorn."""
+
+    load_dotenv()
+    uvicorn.run(
+        "sentinela.services.publications.api:create_app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8000")),
+        factory=True,
+    )
+
+
+__all__ = [
+    "ArticleResponse",
+    "create_app",
+    "configure_cors",
+    "include_routes",
+    "run",
+]

--- a/sentinela/services/publications/container.py
+++ b/sentinela/services/publications/container.py
@@ -1,0 +1,33 @@
+"""Dependency container for publications queries."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentinela.application.services import ArticleQueryService
+from sentinela.infrastructure.database import MongoClientFactory
+from sentinela.infrastructure.repositories import MongoArticleReadRepository
+
+
+@dataclass
+class PublicationsContainer:
+    """Container exposing publication query dependencies."""
+
+    article_repository: MongoArticleReadRepository
+    query_service: ArticleQueryService
+
+
+def build_publications_container(
+    factory: MongoClientFactory | None = None,
+) -> PublicationsContainer:
+    """Build the publications service container."""
+
+    factory = factory or MongoClientFactory()
+    database = factory.get_database()
+
+    article_repository = MongoArticleReadRepository(database["articles"])
+    query_service = ArticleQueryService(article_repository)
+
+    return PublicationsContainer(
+        article_repository=article_repository,
+        query_service=query_service,
+    )


### PR DESCRIPTION
## Summary
- extract the portal and news FastAPI endpoints into dedicated service modules with shared CORS helpers
- add a publications service backed by a read-only Mongo repository and query service for listing articles
- refresh the aggregate API bootstrap and expose new console entrypoints for individual services

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d18276d21c832b9fc021ed1dd5fcb2