### PR TITLE
Add extraction service microservice and integrate with news/publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Após a instalação, o utilitário de linha de comando `sentinela-cli` fica dis
 
 ## Executando a API
 
+## Serviço de Extração
+
+O microserviço de extração (`sentinela.services.extraction`) consome notícias publicadas para identificar pessoas e cidades mencionadas. Após instalar o pacote execute um dos comandos abaixo:
+
+```bash
+sentinela-extraction-api   # expõe rotas REST (/enqueue, /process, /results)
+sentinela-extraction-worker # executa processamento contínuo por lotes
+```
+
+Configure `NER_VERSION`, `GAZETTEER_VERSION` e `EXTRACTION_GAZETTEER_PATH` para controlar reprocessamentos e catálogo de cidades. A coleta de notícias (`sentinela-news-api`) notifica automaticamente o worker usando o `PendingNewsQueue`, e os resultados ficam disponíveis na API de publicações via `/enriched/articles`.
+
+
 Após instalar o pacote, inicie a API REST com o comando:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "uvicorn[standard]>=0.29",
     "sse-starlette>=2.0",
     "python-dotenv>=1.0",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]
@@ -29,4 +30,6 @@ sentinela-api = "sentinela.api:run"
 sentinela-portal-api = "sentinela.services.portals.api:run"
 sentinela-news-api = "sentinela.services.news.api:run"
 sentinela-publications-api = "sentinela.services.publications.api:run"
+sentinela-extraction-api = "sentinela.services.extraction.app:run_api"
+sentinela-extraction-worker = "sentinela.services.extraction.app:run_worker"
 sentinela-cli = "sentinela.cli:main"

--- a/sentinela/services/extraction/__init__.py
+++ b/sentinela/services/extraction/__init__.py
@@ -1,0 +1,37 @@
+"""Application layer helpers for the entity extraction microservice."""
+
+from .adapters import (
+    ExtractionResultStore,
+    ExtractionResultStoreWriter,
+    PendingNewsQueue,
+    PublicationsAPIRepository,
+    QueueNewsRepository,
+)
+from .app import (
+    ExtractionConfig,
+    ExtractionContainer,
+    create_app,
+    build_extraction_container,
+    get_default_pending_queue,
+    get_default_result_store,
+    notify_news_ready,
+    run_api,
+    run_worker,
+)
+
+__all__ = [
+    "ExtractionConfig",
+    "ExtractionContainer",
+    "ExtractionResultStore",
+    "ExtractionResultStoreWriter",
+    "PendingNewsQueue",
+    "PublicationsAPIRepository",
+    "QueueNewsRepository",
+    "build_extraction_container",
+    "create_app",
+    "get_default_pending_queue",
+    "get_default_result_store",
+    "notify_news_ready",
+    "run_api",
+    "run_worker",
+]

--- a/sentinela/services/extraction/adapters.py
+++ b/sentinela/services/extraction/adapters.py
@@ -1,0 +1,388 @@
+"""Adapters used by the extraction microservice service layer."""
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Iterable, Iterator, MutableMapping
+from uuid import uuid4
+
+import requests
+
+from sentinela.extraction import (
+    CityOccurrence,
+    NewsDocument,
+    NewsRepository,
+    PersonOccurrence,
+    ExtractionResultWriter,
+)
+
+
+@dataclass
+class PendingNewsQueue:
+    """In-memory queue coordinating pending news delivery between services."""
+
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _queue: list[NewsDocument] = field(default_factory=list, init=False, repr=False)
+    _inflight: MutableMapping[str, NewsDocument] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def enqueue(self, document: NewsDocument) -> None:
+        """Add a document to the pending queue."""
+
+        with self._lock:
+            if document.url in self._inflight:
+                # Avoid duplicating inflight messages. It will be re-queued on error.
+                return
+            self._queue.append(document)
+
+    def pull(self, batch_size: int) -> list[NewsDocument]:
+        """Return up to ``batch_size`` documents, marking them as inflight."""
+
+        batch: list[NewsDocument] = []
+        with self._lock:
+            while self._queue and len(batch) < batch_size:
+                document = self._queue.pop(0)
+                self._inflight[document.url] = document
+                batch.append(document)
+        return batch
+
+    def ack(self, url: str) -> None:
+        """Acknowledge processing of the document with the given URL."""
+
+        with self._lock:
+            self._inflight.pop(url, None)
+
+    def retry(self, url: str) -> None:
+        """Return a document to the queue so it can be retried."""
+
+        with self._lock:
+            document = self._inflight.pop(url, None)
+            if document:
+                self._queue.append(document)
+
+    def queued_count(self) -> int:
+        """Number of documents waiting to be processed."""
+
+        with self._lock:
+            return len(self._queue)
+
+    def inflight_count(self) -> int:
+        """Number of documents currently being processed."""
+
+        with self._lock:
+            return len(self._inflight)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial helper
+        with self._lock:
+            return len(self._queue) + len(self._inflight)
+
+
+class QueueNewsRepository(NewsRepository):
+    """``NewsRepository`` backed by :class:`PendingNewsQueue`."""
+
+    def __init__(self, queue: PendingNewsQueue) -> None:
+        self._queue = queue
+
+    def fetch_pending(
+        self, batch_size: int, ner_version: str, gazetteer_version: str
+    ) -> Iterable[NewsDocument]:
+        return self._queue.pull(batch_size)
+
+    def mark_processed(
+        self, url: str, ner_version: str, gazetteer_version: str, processed_at: datetime
+    ) -> None:
+        self._queue.ack(url)
+
+    def mark_error(self, url: str, message: str) -> None:
+        self._queue.retry(url)
+
+
+class PublicationsAPIRepository(NewsRepository):
+    """``NewsRepository`` implementation talking to the publications HTTP API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        session: requests.Session | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._session = session or requests.Session()
+        self._timeout = timeout
+
+    def fetch_pending(
+        self, batch_size: int, ner_version: str, gazetteer_version: str
+    ) -> Iterable[NewsDocument]:
+        response = self._session.get(
+            f"{self._base_url}/extraction/pending",
+            params={
+                "limit": batch_size,
+                "ner_version": ner_version,
+                "gazetteer_version": gazetteer_version,
+            },
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("items", [])
+        return [self._deserialize(item) for item in items]
+
+    def mark_processed(
+        self, url: str, ner_version: str, gazetteer_version: str, processed_at: datetime
+    ) -> None:
+        self._session.post(
+            f"{self._base_url}/extraction/processed",
+            json={
+                "url": url,
+                "ner_version": ner_version,
+                "gazetteer_version": gazetteer_version,
+                "processed_at": processed_at.isoformat(),
+            },
+            timeout=self._timeout,
+        ).raise_for_status()
+
+    def mark_error(self, url: str, message: str) -> None:
+        self._session.post(
+            f"{self._base_url}/extraction/error",
+            json={"url": url, "message": message},
+            timeout=self._timeout,
+        ).raise_for_status()
+
+    @staticmethod
+    def _deserialize(data: dict) -> NewsDocument:
+        published_raw = data.get("published_at")
+        published_at = _parse_datetime(published_raw)
+        return NewsDocument(
+            url=str(data["url"]),
+            title=str(data.get("title") or ""),
+            body=str(data.get("body") or data.get("content") or ""),
+            published_at=published_at,
+            source=data.get("source"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EnrichedArticleResult:
+    """Snapshot of the enriched entities associated with a news article."""
+
+    url: str
+    ner_version: str
+    gazetteer_version: str
+    updated_at: datetime
+    people: tuple[PersonOccurrence, ...]
+    cities: tuple[CityOccurrence, ...]
+
+
+@dataclass
+class _StoredResult:
+    url: str
+    ner_version: str
+    gazetteer_version: str
+    people: list[PersonOccurrence] = field(default_factory=list)
+    cities: list[CityOccurrence] = field(default_factory=list)
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def snapshot(self) -> EnrichedArticleResult:
+        return EnrichedArticleResult(
+            url=self.url,
+            ner_version=self.ner_version,
+            gazetteer_version=self.gazetteer_version,
+            updated_at=self.updated_at,
+            people=tuple(self.people),
+            cities=tuple(self.cities),
+        )
+
+
+class ExtractionResultStore:
+    """Thread-safe store containing enriched extraction results."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._people_index: dict[str, str] = {}
+        self._aliases: dict[str, set[str]] = {}
+        self._results: dict[str, _StoredResult] = {}
+
+    def ensure_person(self, canonical_name: str, aliases: set[str]) -> str:
+        with self._lock:
+            person_id = self._people_index.get(canonical_name)
+            if not person_id:
+                person_id = str(uuid4())
+                self._people_index[canonical_name] = person_id
+                self._aliases[person_id] = set(aliases)
+            else:
+                self._aliases.setdefault(person_id, set()).update(aliases)
+            return person_id
+
+    def _ensure_record(
+        self, url: str, ner_version: str, gazetteer_version: str
+    ) -> _StoredResult:
+        record = self._results.get(url)
+        if record is None:
+            record = _StoredResult(
+                url=url,
+                ner_version=ner_version,
+                gazetteer_version=gazetteer_version,
+            )
+            self._results[url] = record
+        elif (
+            record.ner_version != ner_version
+            or record.gazetteer_version != gazetteer_version
+        ):
+            record.ner_version = ner_version
+            record.gazetteer_version = gazetteer_version
+            record.people.clear()
+            record.cities.clear()
+        record.updated_at = datetime.now(timezone.utc)
+        return record
+
+    def append_person(
+        self,
+        url: str,
+        occurrence: PersonOccurrence,
+        *,
+        ner_version: str,
+        gazetteer_version: str,
+    ) -> None:
+        with self._lock:
+            record = self._ensure_record(url, ner_version, gazetteer_version)
+            record.people = _append_unique_person(record.people, occurrence)
+
+    def append_city(
+        self,
+        url: str,
+        occurrence: CityOccurrence,
+        *,
+        ner_version: str,
+        gazetteer_version: str,
+    ) -> None:
+        with self._lock:
+            record = self._ensure_record(url, ner_version, gazetteer_version)
+            record.cities = _append_unique_city(record.cities, occurrence)
+
+    def get(self, url: str) -> EnrichedArticleResult | None:
+        with self._lock:
+            record = self._results.get(url)
+            if not record:
+                return None
+            return record.snapshot()
+
+    def list(self) -> Iterator[EnrichedArticleResult]:
+        with self._lock:
+            for record in list(self._results.values()):
+                yield record.snapshot()
+
+    def serialize(self) -> str:
+        """Serialize the store content for debugging purposes."""  # pragma: no cover
+
+        payload = {
+            url: {
+                "ner_version": record.ner_version,
+                "gazetteer_version": record.gazetteer_version,
+                "updated_at": record.updated_at.isoformat(),
+                "people": [asdict(occ) for occ in record.people],
+                "cities": [
+                    {
+                        **asdict(occ),
+                        "candidates": [asdict(candidate) for candidate in occ.candidates],
+                    }
+                    for occ in record.cities
+                ],
+            }
+            for url, record in self._results.items()
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+class ExtractionResultStoreWriter(ExtractionResultWriter):
+    """Store-backed ``ExtractionResultWriter`` implementation."""
+
+    def __init__(
+        self,
+        store: ExtractionResultStore,
+        *,
+        ner_version: str,
+        gazetteer_version: str,
+    ) -> None:
+        self._store = store
+        self._ner_version = ner_version
+        self._gazetteer_version = gazetteer_version
+
+    def ensure_person(self, canonical_name: str, aliases: set[str]) -> str:
+        return self._store.ensure_person(canonical_name, aliases)
+
+    def record_person_occurrence(self, url: str, occurrence: PersonOccurrence) -> None:
+        self._store.append_person(
+            url,
+            occurrence,
+            ner_version=self._ner_version,
+            gazetteer_version=self._gazetteer_version,
+        )
+
+    def record_city_occurrence(self, url: str, occurrence: CityOccurrence) -> None:
+        self._store.append_city(
+            url,
+            occurrence,
+            ner_version=self._ner_version,
+            gazetteer_version=self._gazetteer_version,
+        )
+
+
+def _parse_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"):
+            try:
+                parsed = datetime.strptime(value, fmt)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                return parsed
+            except ValueError:
+                continue
+    return datetime.fromtimestamp(0, timezone.utc)
+
+
+def _append_unique_person(
+    values: list[PersonOccurrence], occurrence: PersonOccurrence
+) -> list[PersonOccurrence]:
+    filtered = [
+        value
+        for value in values
+        if not (
+            value.person_id == occurrence.person_id
+            and value.start == occurrence.start
+            and value.end == occurrence.end
+        )
+    ]
+    filtered.append(occurrence)
+    return filtered
+
+
+def _append_unique_city(
+    values: list[CityOccurrence], occurrence: CityOccurrence
+) -> list[CityOccurrence]:
+    filtered = [
+        value
+        for value in values
+        if not (
+            value.city_id == occurrence.city_id
+            and value.start == occurrence.start
+            and value.end == occurrence.end
+        )
+    ]
+    filtered.append(occurrence)
+    return filtered
+
+
+__all__ = [
+    "EnrichedArticleResult",
+    "ExtractionResultStore",
+    "ExtractionResultStoreWriter",
+    "PendingNewsQueue",
+    "PublicationsAPIRepository",
+    "QueueNewsRepository",
+]

--- a/sentinela/services/extraction/app.py
+++ b/sentinela/services/extraction/app.py
@@ -1,0 +1,532 @@
+"""FastAPI/worker application for the entity extraction microservice."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from importlib import import_module
+from typing import Any, Iterable
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from sentinela.domain.entities import Article
+from sentinela.extraction import CityGazetteer, CityRecord, EntityExtractionService, NewsDocument
+from sentinela.extraction.ner import NEREngine
+from sentinela.extraction.models import ExtractionResultWriter, NewsRepository
+
+from .adapters import (
+    EnrichedArticleResult,
+    ExtractionResultStore,
+    ExtractionResultStoreWriter,
+    PendingNewsQueue,
+    QueueNewsRepository,
+)
+
+
+_DEFAULT_QUEUE: PendingNewsQueue | None = None
+_DEFAULT_RESULT_STORE: ExtractionResultStore | None = None
+
+
+@dataclass
+class ExtractionConfig:
+    """Configuration required to bootstrap the extraction service."""
+
+    ner_version: str
+    gazetteer_version: str
+    batch_size: int = 500
+    ner_engine_factory: str | None = None
+    ner_engine_settings: dict[str, Any] = field(default_factory=dict)
+    gazetteer_path: str | None = None
+    news_backend: str = "queue"
+    publications_api_url: str | None = None
+    result_backend: str = "memory"
+    ner_engine: NEREngine | None = None
+    gazetteer: CityGazetteer | None = None
+    news_repository: NewsRepository | None = None
+    result_writer: ExtractionResultWriter | None = None
+    queue: PendingNewsQueue | None = None
+    result_store: ExtractionResultStore | None = None
+
+    @classmethod
+    def from_env(cls) -> "ExtractionConfig":
+        """Build a configuration instance from environment variables."""
+
+        def _json_env(name: str) -> dict[str, Any]:
+            raw = os.getenv(name)
+            if not raw:
+                return {}
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise RuntimeError(f"Invalid JSON in environment variable {name!r}: {raw}") from exc
+
+        return cls(
+            ner_version=os.getenv("NER_VERSION", "dev"),
+            gazetteer_version=os.getenv("GAZETTEER_VERSION", "dev"),
+            batch_size=int(os.getenv("EXTRACTION_BATCH_SIZE", "500")),
+            ner_engine_factory=os.getenv(
+                "EXTRACTION_NER_FACTORY",
+                "sentinela.services.extraction.app:create_default_ner_engine",
+            ),
+            ner_engine_settings=_json_env("EXTRACTION_NER_SETTINGS"),
+            gazetteer_path=os.getenv("EXTRACTION_GAZETTEER_PATH"),
+            news_backend=os.getenv("EXTRACTION_NEWS_BACKEND", "queue"),
+            publications_api_url=os.getenv("PUBLICATIONS_API_URL"),
+            result_backend=os.getenv("EXTRACTION_RESULT_BACKEND", "memory"),
+        )
+
+
+@dataclass
+class ExtractionContainer:
+    """Resolved dependencies for the extraction service."""
+
+    config: ExtractionConfig
+    service: EntityExtractionService
+    news_repository: NewsRepository
+    result_writer: ExtractionResultWriter
+    ner_engine: NEREngine
+    gazetteer: CityGazetteer
+    queue: PendingNewsQueue | None
+    result_store: ExtractionResultStore
+
+
+def get_default_pending_queue() -> PendingNewsQueue:
+    """Return a shared in-memory queue instance."""
+
+    global _DEFAULT_QUEUE
+    if _DEFAULT_QUEUE is None:
+        _DEFAULT_QUEUE = PendingNewsQueue()
+    return _DEFAULT_QUEUE
+
+
+def set_default_pending_queue(queue: PendingNewsQueue) -> None:
+    global _DEFAULT_QUEUE
+    _DEFAULT_QUEUE = queue
+
+
+def get_default_result_store() -> ExtractionResultStore:
+    """Return the global extraction result store."""
+
+    global _DEFAULT_RESULT_STORE
+    if _DEFAULT_RESULT_STORE is None:
+        _DEFAULT_RESULT_STORE = ExtractionResultStore()
+    return _DEFAULT_RESULT_STORE
+
+
+def set_default_result_store(store: ExtractionResultStore) -> None:
+    global _DEFAULT_RESULT_STORE
+    _DEFAULT_RESULT_STORE = store
+
+
+def build_extraction_container(config: ExtractionConfig) -> ExtractionContainer:
+    """Instantiate all dependencies required by the extraction service."""
+
+    ner_engine = config.ner_engine or _load_ner_engine(
+        config.ner_engine_factory, config.ner_engine_settings
+    )
+    gazetteer = config.gazetteer or _load_gazetteer(config.gazetteer_path)
+
+    if config.news_repository is not None:
+        news_repository = config.news_repository
+        queue = config.queue
+    elif config.news_backend == "queue":
+        queue = config.queue if config.queue is not None else get_default_pending_queue()
+        news_repository = QueueNewsRepository(queue)
+    else:
+        raise ValueError(
+            "Unsupported news backend: {backend}".format(backend=config.news_backend)
+        )
+
+    if config.result_writer is not None:
+        result_writer = config.result_writer
+        store = config.result_store or get_default_result_store()
+    elif config.result_backend == "memory":
+        store = config.result_store if config.result_store is not None else get_default_result_store()
+        result_writer = ExtractionResultStoreWriter(
+            store,
+            ner_version=config.ner_version,
+            gazetteer_version=config.gazetteer_version,
+        )
+    else:
+        raise ValueError(
+            "Unsupported result backend: {backend}".format(backend=config.result_backend)
+        )
+
+    config.queue = queue
+    config.result_store = store
+
+    set_default_pending_queue(queue)
+    set_default_result_store(store)
+
+    service = EntityExtractionService(
+        news_repository=news_repository,
+        result_writer=result_writer,
+        ner_engine=ner_engine,
+        gazetteer=gazetteer,
+        ner_version=config.ner_version,
+        gazetteer_version=config.gazetteer_version,
+        batch_size=config.batch_size,
+    )
+
+    return ExtractionContainer(
+        config=config,
+        service=service,
+        news_repository=news_repository,
+        result_writer=result_writer,
+        ner_engine=ner_engine,
+        gazetteer=gazetteer,
+        queue=queue,
+        result_store=store,
+    )
+
+
+def notify_news_ready(articles: Iterable[Article]) -> int:
+    """Publish newly collected articles to the extraction queue."""
+
+    queue = get_default_pending_queue()
+    total = 0
+    for article in articles:
+        published_at = article.published_at
+        if published_at.tzinfo is None:
+            published_at = published_at.replace(tzinfo=timezone.utc)
+        queue.enqueue(
+            NewsDocument(
+                url=article.url,
+                title=article.title,
+                body=article.content,
+                published_at=published_at,
+                source=article.portal_name,
+            )
+        )
+        total += 1
+    return total
+
+
+class NewsPayload(BaseModel):
+    """Incoming representation of a pending news document."""
+
+    url: str
+    title: str | None = None
+    body: str | None = None
+    content: str | None = None
+    published_at: datetime | None = None
+    source: str | None = None
+
+    def to_document(self) -> NewsDocument:
+        body = self.body if self.body is not None else (self.content or "")
+        published_at = self.published_at or datetime.now(timezone.utc)
+        if published_at.tzinfo is None:
+            published_at = published_at.replace(tzinfo=timezone.utc)
+        return NewsDocument(
+            url=self.url,
+            title=self.title or "",
+            body=body,
+            published_at=published_at,
+            source=self.source,
+        )
+
+
+class BatchProcessRequest(BaseModel):
+    """Optional overrides for batch processing."""
+
+    batch_size: int | None = Field(default=None, ge=1, le=5000)
+
+
+class BatchProcessResponse(BaseModel):
+    processed: int
+    skipped_empty: int
+    errors: list[dict[str, str]]
+
+
+class CandidateResponse(BaseModel):
+    city_id: str
+    name: str
+    uf: str
+    score: float
+
+
+class PersonOccurrenceResponse(BaseModel):
+    person_id: str
+    canonical_name: str
+    surface: str
+    start: int
+    end: int
+    sentence: str
+    method: str
+    confidence: float
+
+    @classmethod
+    def from_dataclass(cls, occurrence) -> "PersonOccurrenceResponse":
+        return cls(
+            person_id=occurrence.person_id,
+            canonical_name=occurrence.canonical_name,
+            surface=occurrence.surface,
+            start=occurrence.start,
+            end=occurrence.end,
+            sentence=occurrence.sentence,
+            method=occurrence.method,
+            confidence=occurrence.confidence,
+        )
+
+
+class CityOccurrenceResponse(BaseModel):
+    city_id: str | None
+    surface: str
+    start: int
+    end: int
+    sentence: str
+    status: str
+    uf_surface: str | None
+    method: str
+    confidence: float
+    candidates: list[CandidateResponse]
+
+    @classmethod
+    def from_dataclass(cls, occurrence) -> "CityOccurrenceResponse":
+        return cls(
+            city_id=occurrence.city_id,
+            surface=occurrence.surface,
+            start=occurrence.start,
+            end=occurrence.end,
+            sentence=occurrence.sentence,
+            status=occurrence.status,
+            uf_surface=occurrence.uf_surface,
+            method=occurrence.method,
+            confidence=occurrence.confidence,
+            candidates=[
+                CandidateResponse(
+                    city_id=candidate.city_id,
+                    name=candidate.name,
+                    uf=candidate.uf,
+                    score=candidate.score,
+                )
+                for candidate in occurrence.candidates
+            ],
+        )
+
+
+class EnrichedArticleResponse(BaseModel):
+    url: str
+    ner_version: str
+    gazetteer_version: str
+    updated_at: datetime
+    people: list[PersonOccurrenceResponse]
+    cities: list[CityOccurrenceResponse]
+
+    @classmethod
+    def from_store(cls, result: EnrichedArticleResult) -> "EnrichedArticleResponse":
+        return cls(
+            url=result.url,
+            ner_version=result.ner_version,
+            gazetteer_version=result.gazetteer_version,
+            updated_at=result.updated_at,
+            people=[PersonOccurrenceResponse.from_dataclass(item) for item in result.people],
+            cities=[CityOccurrenceResponse.from_dataclass(item) for item in result.cities],
+        )
+
+
+def include_routes(app: FastAPI, container: ExtractionContainer, *, prefix: str = "") -> None:
+    """Register FastAPI routes exposing the extraction capabilities."""
+
+    router = APIRouter(prefix=prefix, tags=["Extraction"])
+
+    @router.get("/healthz")
+    def healthcheck() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @router.post("/enqueue")
+    def enqueue_news(payload: list[NewsPayload] | NewsPayload) -> dict[str, Any]:
+        if container.queue is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Queue backend not configured on this instance.",
+            )
+        items = payload if isinstance(payload, list) else [payload]
+        for item in items:
+            container.queue.enqueue(item.to_document())
+        return {"queued": len(items)}
+
+    @router.post("/process", response_model=BatchProcessResponse)
+    def trigger_processing(payload: BatchProcessRequest | None = None) -> BatchProcessResponse:
+        if payload and payload.batch_size and payload.batch_size != container.config.batch_size:
+            container.config.batch_size = payload.batch_size
+            container.service = EntityExtractionService(
+                news_repository=container.news_repository,
+                result_writer=container.result_writer,
+                ner_engine=container.ner_engine,
+                gazetteer=container.gazetteer,
+                ner_version=container.config.ner_version,
+                gazetteer_version=container.config.gazetteer_version,
+                batch_size=payload.batch_size,
+            )
+        result = container.service.process_next_batch()
+        return BatchProcessResponse(
+            processed=result.processed,
+            skipped_empty=result.skipped_empty,
+            errors=[{"url": url, "message": message} for url, message in result.errors],
+        )
+
+    @router.get("/results", response_model=list[EnrichedArticleResponse])
+    def list_results() -> list[EnrichedArticleResponse]:
+        return [EnrichedArticleResponse.from_store(result) for result in container.result_store.list()]
+
+    @router.get("/results/{url:path}", response_model=EnrichedArticleResponse)
+    def get_result(url: str) -> EnrichedArticleResponse:
+        result = container.result_store.get(url)
+        if not result:
+            raise HTTPException(status_code=404, detail="Resultado não encontrado")
+        return EnrichedArticleResponse.from_store(result)
+
+    if container.queue is not None:
+        @router.get("/queue", response_model=dict)
+        def queue_stats() -> dict[str, int]:
+            return {
+                "queued": container.queue.queued_count(),
+                "inflight": container.queue.inflight_count(),
+            }
+
+    app.include_router(router)
+
+
+def create_app(config: ExtractionConfig | None = None) -> FastAPI:
+    """Create a FastAPI application exposing extraction endpoints."""
+
+    config = config or ExtractionConfig.from_env()
+    container = build_extraction_container(config)
+
+    app = FastAPI(
+        title="Sentinela Extraction API",
+        version="1.0.0",
+        description="Processamento de entidades (pessoas e cidades) em notícias coletadas.",
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    include_routes(app, container)
+    app.state.container = container
+    return app
+
+
+def create_default_ner_engine(**_: Any) -> NEREngine:
+    """Fallback NER engine that does not yield any entities."""
+
+    class NoOpNER(NEREngine):
+        def analyze(self, text: str) -> Iterable[Any]:  # pragma: no cover - simple default
+            return []
+
+    return NoOpNER()
+
+
+def run_api() -> None:
+    """Run the extraction API with uvicorn."""
+
+    load_dotenv()
+    uvicorn.run(
+        "sentinela.services.extraction.app:create_app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8002")),
+        factory=True,
+    )
+
+
+def run_worker() -> None:
+    """Continuously process pending batches using the configured backend."""
+
+    load_dotenv()
+    log = logging.getLogger("sentinela.extraction.worker")
+    interval = int(os.getenv("EXTRACTION_WORKER_INTERVAL", "60"))
+    config = ExtractionConfig.from_env()
+    container = build_extraction_container(config)
+
+    log.info(
+        "Iniciando worker de extração (batch_size=%s, ner_version=%s, gazetteer_version=%s)",
+        config.batch_size,
+        config.ner_version,
+        config.gazetteer_version,
+    )
+
+    try:
+        while True:
+            result = container.service.process_next_batch()
+            log.info(
+                "Lote processado: %s notícias, %s vazias, %s erros",
+                result.processed,
+                result.skipped_empty,
+                len(result.errors),
+            )
+            if result.errors:
+                for url, message in result.errors:
+                    log.error("Falha ao processar %s: %s", url, message)
+            if interval <= 0:
+                break
+            time.sleep(interval)
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        log.info("Worker interrompido pelo usuário")
+
+
+def _load_ner_engine(
+    factory_path: str | None, settings: dict[str, Any]
+) -> NEREngine:
+    if factory_path is None:
+        return create_default_ner_engine()
+    module_name, _, attribute = factory_path.partition(":")
+    if not attribute:
+        raise ValueError(
+            "EXTRACTION_NER_FACTORY deve seguir o formato 'modulo:atributo'"
+        )
+    module = import_module(module_name)
+    factory = getattr(module, attribute)
+    if callable(factory):
+        return factory(**settings)
+    return factory
+
+
+def _load_gazetteer(path: str | None) -> CityGazetteer:
+    if not path:
+        return CityGazetteer([])
+    with open(path, "r", encoding="utf-8") as stream:
+        payload = json.load(stream)
+    records: list[CityRecord] = []
+    for item in payload:
+        records.append(
+            CityRecord(
+                id=str(item["id"]),
+                name=item["name"],
+                uf=item.get("uf", ""),
+                alt_names=tuple(item.get("alt_names", [])),
+                latitude=item.get("latitude"),
+                longitude=item.get("longitude"),
+                country=item.get("country", "BR"),
+            )
+        )
+    return CityGazetteer(records)
+
+
+__all__ = [
+    "BatchProcessRequest",
+    "BatchProcessResponse",
+    "ExtractionConfig",
+    "ExtractionContainer",
+    "EnrichedArticleResponse",
+    "NewsPayload",
+    "build_extraction_container",
+    "create_app",
+    "create_default_ner_engine",
+    "get_default_pending_queue",
+    "get_default_result_store",
+    "include_routes",
+    "notify_news_ready",
+    "run_api",
+    "run_worker",
+]

--- a/sentinela/services/publications/container.py
+++ b/sentinela/services/publications/container.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from sentinela.application.services import ArticleQueryService
 from sentinela.infrastructure.database import MongoClientFactory
 from sentinela.infrastructure.repositories import MongoArticleReadRepository
+from sentinela.services.extraction import ExtractionResultStore, get_default_result_store
 
 
 @dataclass
@@ -14,6 +15,7 @@ class PublicationsContainer:
 
     article_repository: MongoArticleReadRepository
     query_service: ArticleQueryService
+    extraction_store: ExtractionResultStore
 
 
 def build_publications_container(
@@ -30,4 +32,5 @@ def build_publications_container(
     return PublicationsContainer(
         article_repository=article_repository,
         query_service=query_service,
+        extraction_store=get_default_result_store(),
     )

--- a/tests/test_extraction_service_app.py
+++ b/tests/test_extraction_service_app.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from urllib.parse import quote
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from sentinela.domain.entities import Article
+from sentinela.extraction import CityGazetteer, CityRecord, NewsDocument
+from sentinela.extraction.models import EntitySpan
+from sentinela.services.extraction import (
+    ExtractionConfig,
+    build_extraction_container,
+    create_app,
+    notify_news_ready,
+)
+from sentinela.services.extraction.adapters import ExtractionResultStore, PendingNewsQueue
+from sentinela.services.publications import PublicationsContainer
+from sentinela.services.publications.api import include_routes
+
+
+_SAMPLE_TEXT = "Maria Silva esteve em Florianópolis-SC acompanhada da comitiva."
+
+
+class FakeNER:
+    def __init__(self, spans: list[EntitySpan]):
+        self._spans = spans
+
+    def analyze(self, text: str):
+        for span in self._spans:
+            yield span
+
+
+def _build_container() -> tuple:
+    queue = PendingNewsQueue()
+    store = ExtractionResultStore()
+    city = CityRecord(id="4205407", name="Florianópolis", uf="SC", alt_names=("Floripa",))
+    gazetteer = CityGazetteer([city])
+    spans = [
+        EntitySpan(label="PERSON", text="Maria Silva", start=0, end=11, score=0.9, method="test"),
+        EntitySpan(
+            label="LOC",
+            text="Florianópolis",
+            start=_SAMPLE_TEXT.index("Florianópolis"),
+            end=_SAMPLE_TEXT.index("Florianópolis") + len("Florianópolis"),
+            score=0.8,
+            method="test",
+        ),
+    ]
+    config = ExtractionConfig(
+        ner_version="ner-1",
+        gazetteer_version="gaz-1",
+        batch_size=5,
+        ner_engine=FakeNER(spans),
+        gazetteer=gazetteer,
+        queue=queue,
+        result_store=store,
+    )
+    container = build_extraction_container(config)
+    return container, queue, store
+
+
+def _sample_document() -> NewsDocument:
+    return NewsDocument(
+        url="https://example.com/news/1",
+        title="Maria Silva visitou Florianópolis",
+        body=_SAMPLE_TEXT,
+        published_at=datetime(2024, 5, 12, tzinfo=timezone.utc),
+        source="Diário", 
+    )
+
+
+def test_queue_processing_records_results():
+    container, queue, store = _build_container()
+    document = _sample_document()
+    queue.enqueue(document)
+
+    result = container.service.process_next_batch()
+
+    assert result.processed == 1
+    enriched = store.get(document.url)
+    assert enriched is not None
+    assert enriched.ner_version == "ner-1"
+    assert enriched.people and enriched.people[0].canonical_name == "Maria Silva"
+    assert enriched.cities and enriched.cities[0].city_id == "4205407"
+
+
+def test_extraction_api_flow_and_publications_endpoint():
+    container, queue, store = _build_container()
+    config = container.config
+    config.queue = queue
+    config.result_store = store
+    config.ner_engine = container.ner_engine
+    config.gazetteer = container.gazetteer
+
+    app = create_app(config)
+    client = TestClient(app)
+
+    payload = {
+        "url": "https://example.com/news/1",
+        "title": "Maria Silva visitou Florianópolis",
+        "content": _SAMPLE_TEXT,
+        "published_at": "2024-05-12T00:00:00+00:00",
+        "source": "Diário",
+    }
+    enqueue_response = client.post("/enqueue", json=payload)
+    assert enqueue_response.status_code == 200
+    assert enqueue_response.json() == {"queued": 1}
+
+    process_response = client.post("/process")
+    assert process_response.status_code == 200
+    body = process_response.json()
+    assert body["processed"] == 1
+    assert body["errors"] == []
+
+    encoded_url = quote(payload["url"], safe="")
+    result_response = client.get(f"/results/{encoded_url}")
+    assert result_response.status_code == 200
+    data = result_response.json()
+    assert data["people"][0]["canonical_name"] == "Maria Silva"
+    assert data["cities"][0]["city_id"] == "4205407"
+
+    article = Article(
+        portal_name="Diário",
+        title=payload["title"],
+        url=payload["url"],
+        content=payload["content"],
+        summary=None,
+        published_at=datetime(2024, 5, 12, tzinfo=timezone.utc),
+    )
+    notify_news_ready([article])
+    assert queue.queued_count() >= 1
+
+    publications_app = FastAPI()
+    dummy_container = PublicationsContainer(
+        article_repository=SimpleNamespace(),
+        query_service=SimpleNamespace(list_articles=lambda *args, **kwargs: []),
+        extraction_store=store,
+    )
+    include_routes(publications_app, dummy_container)
+    publications_client = TestClient(publications_app)
+    enriched_response = publications_client.get("/enriched/articles")
+    assert enriched_response.status_code == 200
+    enriched_body = enriched_response.json()
+    assert enriched_body and enriched_body[0]["url"] == payload["url"]
+
+    enriched_detail = publications_client.get(f"/enriched/articles/{encoded_url}")
+    assert enriched_detail.status_code == 200


### PR DESCRIPTION
## Summary
- introduce `sentinela.services.extraction` package providing configuration, queue-backed news repository, in-memory result store and FastAPI/worker entrypoints for entity extraction
- wire the news collection API to notify the extraction queue, expose enriched entity endpoints in the publications API, and document the new scripts and environment variables
- add integration tests covering the extraction API flow and the publications enrichment endpoints, and register CLI commands plus HTTPX dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d187c320f4832b900f3993ed070a2b