### PR TITLE
Refatorar coleta para usar portas remotas

### DIFF
--- a/sentinela/cli.py
+++ b/sentinela/cli.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 from sentinela.domain.entities import Portal, PortalSelectors, Selector
 from sentinela.services.news import build_news_container
 from sentinela.services.portals import build_portals_container
+from sentinela.services.publications import build_publications_container
 
 
 def parse_args() -> argparse.Namespace:
@@ -83,6 +84,7 @@ def main() -> None:
     )
     portals_container = build_portals_container()
     news_container = build_news_container()
+    publications_container = build_publications_container()
 
     if args.command == "register-portal":
         portal = _load_portal_from_json(args.path)
@@ -105,7 +107,7 @@ def main() -> None:
     elif args.command == "list-articles":
         start_date = _parse_date(args.start_date)
         end_date = _parse_date(args.end_date)
-        for article in news_container.collector_service.list_articles(
+        for article in publications_container.query_service.list_articles(
             args.portal, start_date, end_date
         ):
             print(

--- a/sentinela/domain/__init__.py
+++ b/sentinela/domain/__init__.py
@@ -6,19 +6,18 @@ consumers can import from ``sentinela.domain`` directly, e.g.::
     from sentinela.domain import Portal, Article, PortalRepository
 """
 
-from .entities import (
-    Article,
-    Portal,
-    PortalSelectors,
-    Selector,
-)
-from .repositories import ArticleRepository, PortalRepository
+from .entities import Article, Portal, PortalSelectors, Selector
+from .ports import ArticleSink, PortalGateway
+from .repositories import ArticleReadRepository, ArticleRepository, PortalRepository
 
 __all__ = [
     "Selector",
     "PortalSelectors",
     "Portal",
     "Article",
+    "PortalGateway",
     "PortalRepository",
+    "ArticleSink",
     "ArticleRepository",
+    "ArticleReadRepository",
 ]

--- a/sentinela/domain/ports.py
+++ b/sentinela/domain/ports.py
@@ -1,0 +1,24 @@
+"""Domain ports exposed for external integrations."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+from .entities import Article, Portal
+
+
+class PortalGateway(ABC):
+    """Defines how portal configurations are retrieved from external services."""
+
+    @abstractmethod
+    def get_portal(self, name: str) -> Portal | None:
+        """Return the portal identified by ``name`` or ``None`` if unavailable."""
+
+
+class ArticleSink(ABC):
+    """Abstraction responsible for persisting collected articles."""
+
+    @abstractmethod
+    def persist(self, articles: Iterable[Article]) -> list[Article]:
+        """Persist ``articles`` and return only the newly stored instances."""
+

--- a/sentinela/services/news/clients.py
+++ b/sentinela/services/news/clients.py
@@ -1,0 +1,113 @@
+"""Clients used by the news service to integrate with remote microservices."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable
+
+import requests
+
+from sentinela.domain.entities import Article, Portal, PortalSelectors, Selector
+from sentinela.domain.ports import ArticleSink, PortalGateway
+
+
+def _join_url(base: str, path: str) -> str:
+    base = base.rstrip("/")
+    path = path.lstrip("/")
+    return f"{base}/{path}" if path else base
+
+
+def _build_selector(data: dict[str, str | None]) -> Selector:
+    return Selector(query=data["query"], attribute=data.get("attribute"))
+
+
+def _build_portal(data: dict) -> Portal:
+    selectors = data["selectors"]
+    return Portal(
+        name=data["name"],
+        base_url=data["base_url"],
+        listing_path_template=data["listing_path_template"],
+        headers=data.get("headers", {}),
+        date_format=data.get("date_format", "%Y-%m-%d"),
+        selectors=PortalSelectors(
+            listing_article=_build_selector(selectors["listing_article"]),
+            listing_title=_build_selector(selectors["listing_title"]),
+            listing_url=_build_selector(selectors["listing_url"]),
+            article_content=_build_selector(selectors["article_content"]),
+            article_date=_build_selector(selectors["article_date"]),
+            listing_summary=_build_selector(selectors["listing_summary"])
+            if selectors.get("listing_summary")
+            else None,
+        ),
+    )
+
+
+def _build_article(data: dict) -> Article:
+    return Article(
+        portal_name=data["portal"],
+        title=data["title"],
+        url=data["url"],
+        content=data["content"],
+        summary=data.get("summary"),
+        published_at=datetime.fromisoformat(data["published_at"]),
+        raw=data.get("raw", {}),
+    )
+
+
+def _serialize_article(article: Article) -> dict:
+    return {
+        "portal": article.portal_name,
+        "title": article.title,
+        "url": article.url,
+        "content": article.content,
+        "summary": article.summary,
+        "published_at": article.published_at.isoformat(),
+        "raw": article.raw,
+    }
+
+
+@dataclass
+class PortalServiceClient(PortalGateway):
+    """HTTP client that retrieves portal configurations from the portal service."""
+
+    base_url: str
+    session: requests.Session | None = None
+    timeout: float = 10.0
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+
+    def get_portal(self, name: str) -> Portal | None:
+        url = _join_url(self.base_url, f"portals/{name}")
+        response = self.session.get(url, timeout=self.timeout)
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        data = response.json()
+        return _build_portal(data)
+
+
+@dataclass
+class PublicationServiceClient(ArticleSink):
+    """HTTP client that publishes collected articles to the publications service."""
+
+    base_url: str
+    session: requests.Session | None = None
+    timeout: float = 10.0
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+
+    def persist(self, articles: Iterable[Article]) -> list[Article]:
+        articles = list(articles)
+        if not articles:
+            return []
+        payload = {"articles": [_serialize_article(article) for article in articles]}
+        url = _join_url(self.base_url, "articles")
+        response = self.session.post(url, json=payload, timeout=self.timeout)
+        response.raise_for_status()
+        data = response.json()
+        return [_build_article(item) for item in data]
+

--- a/sentinela/services/news/container.py
+++ b/sentinela/services/news/container.py
@@ -1,48 +1,58 @@
 """Dependency container for news collection services."""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 from sentinela.application.services import NewsCollectorService
-from sentinela.infrastructure.database import MongoClientFactory
-from sentinela.infrastructure.repositories import (
-    MongoArticleRepository,
-    MongoPortalRepository,
-)
 from sentinela.infrastructure.scraper import RequestsSoupScraper
+from .clients import PortalServiceClient, PublicationServiceClient
+
+
+def _default_portals_url() -> str:
+    return os.getenv("PORTALS_SERVICE_URL", "http://localhost:8001")
+
+
+def _default_publications_url() -> str:
+    return os.getenv("PUBLICATIONS_SERVICE_URL", "http://localhost:8002")
 
 
 @dataclass
 class NewsContainer:
     """Container exposing news collection service dependencies."""
 
-    portal_repository: MongoPortalRepository
-    article_repository: MongoArticleRepository
+    portal_gateway: PortalServiceClient
+    article_sink: PublicationServiceClient
     scraper: RequestsSoupScraper
     collector_service: NewsCollectorService
 
 
 def build_news_container(
-    factory: MongoClientFactory | None = None,
+    *,
+    portals_url: str | None = None,
+    publications_url: str | None = None,
 ) -> NewsContainer:
     """Build the news collection service container."""
 
-    factory = factory or MongoClientFactory()
-    database = factory.get_database()
-
-    portal_repository = MongoPortalRepository(database["portals"])
-    article_repository = MongoArticleRepository(database["articles"])
     scraper = RequestsSoupScraper()
+    portal_gateway = PortalServiceClient(portals_url or _default_portals_url())
+    article_sink = PublicationServiceClient(
+        publications_url or _default_publications_url()
+    )
 
     collector_service = NewsCollectorService(
-        portal_repository=portal_repository,
-        article_repository=article_repository,
+        portal_gateway=portal_gateway,
+        article_sink=article_sink,
         scraper=scraper,
     )
 
     return NewsContainer(
-        portal_repository=portal_repository,
-        article_repository=article_repository,
+        portal_gateway=portal_gateway,
+        article_sink=article_sink,
         scraper=scraper,
         collector_service=collector_service,
     )
+
+
+__all__ = ["NewsContainer", "build_news_container"]
+

--- a/sentinela/services/portals/api.py
+++ b/sentinela/services/portals/api.py
@@ -141,6 +141,14 @@ def include_routes(
             for portal in container.portal_service.list_portals()
         ]
 
+    @router.get("/portals/{name}", response_model=PortalResponse)
+    def get_portal(name: str) -> PortalResponse:
+        try:
+            portal = container.portal_service.get_portal(name)
+        except ValueError as exc:
+            raise handle_value_error(exc)
+        return map_portal_response(portal)
+
     app.include_router(router)
 
 

--- a/sentinela/services/publications/adapters.py
+++ b/sentinela/services/publications/adapters.py
@@ -1,0 +1,36 @@
+"""Adapters used by the publications service to receive new articles."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from sentinela.domain.entities import Article
+from sentinela.domain.repositories import ArticleRepository
+
+
+@dataclass
+class ArticleIngestionAdapter:
+    """Filters and persists new articles into the publications datastore."""
+
+    repository: ArticleRepository
+
+    def ingest(self, articles: Iterable[Article]) -> List[Article]:
+        """Persist ``articles`` and return only the ones stored for the first time."""
+
+        unique: dict[tuple[str, str], Article] = {}
+        for article in articles:
+            key = (article.portal_name, article.url)
+            if key not in unique:
+                unique[key] = article
+
+        new_articles = [
+            article
+            for key, article in unique.items()
+            if not self.repository.exists(key[0], key[1])
+        ]
+
+        if new_articles:
+            self.repository.save_many(new_articles)
+
+        return new_articles
+


### PR DESCRIPTION
## Summary
- introduce domain ports for portal configuration and article persistence and refactor NewsCollectorService to publish progress updates through an optional status publisher
- add HTTP clients for the portal and publications services and update the news container and API to use the new remote integrations
- expose REST ingestion capabilities in the publications service, update its container and CLI consumers, and provide a dedicated endpoint to retrieve a portal configuration by name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d186d07db4832baaf4ef1909dfa029