### PR TITLE
Refatorar NewsCollectorService para usar portas remotas

### DIFF
--- a/sentinela/domain/__init__.py
+++ b/sentinela/domain/__init__.py
@@ -12,6 +12,7 @@ from .entities import (
     PortalSelectors,
     Selector,
 )
+from .ports import ArticleSink, PortalGateway
 from .repositories import ArticleRepository, PortalRepository
 
 __all__ = [
@@ -21,4 +22,6 @@ __all__ = [
     "Article",
     "PortalRepository",
     "ArticleRepository",
+    "PortalGateway",
+    "ArticleSink",
 ]

--- a/sentinela/domain/ports.py
+++ b/sentinela/domain/ports.py
@@ -1,0 +1,23 @@
+"""Domain service ports for inter-service communication."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Optional
+
+from .entities import Article, Portal
+
+
+class PortalGateway(ABC):
+    """Access point to retrieve portal configurations from remote services."""
+
+    @abstractmethod
+    def get_portal(self, name: str) -> Optional[Portal]:
+        """Fetch a portal configuration by name."""
+
+
+class ArticleSink(ABC):
+    """Port describing how new articles are persisted externally."""
+
+    @abstractmethod
+    def publish_many(self, articles: Iterable[Article]) -> Iterable[Article]:
+        """Persist a batch of articles and return the ones effectively stored."""

--- a/sentinela/services/news/api.py
+++ b/sentinela/services/news/api.py
@@ -147,7 +147,7 @@ def include_routes(app: FastAPI, container: NewsContainer, *, prefix: str = "") 
                         payload.portal,
                         payload.start_date,
                         end_date,
-                        status_callback=status_callback,
+                        status_publisher=status_callback,
                     ),
                 )
                 response = CollectResponse(

--- a/sentinela/services/news/clients.py
+++ b/sentinela/services/news/clients.py
@@ -1,0 +1,126 @@
+"""HTTP clients used by the news service to communicate with other services."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Optional
+
+import httpx
+
+from sentinela.domain.entities import Article, Portal, PortalSelectors, Selector
+from sentinela.domain.ports import ArticleSink, PortalGateway
+
+
+def _selector_from_payload(payload: dict) -> Selector:
+    return Selector(query=payload["query"], attribute=payload.get("attribute"))
+
+
+def _portal_from_payload(payload: dict) -> Portal:
+    selectors = payload["selectors"]
+    return Portal(
+        name=payload["name"],
+        base_url=payload["base_url"],
+        listing_path_template=payload["listing_path_template"],
+        selectors=PortalSelectors(
+            listing_article=_selector_from_payload(selectors["listing_article"]),
+            listing_title=_selector_from_payload(selectors["listing_title"]),
+            listing_url=_selector_from_payload(selectors["listing_url"]),
+            article_content=_selector_from_payload(selectors["article_content"]),
+            article_date=_selector_from_payload(selectors["article_date"]),
+            listing_summary=
+                _selector_from_payload(selectors["listing_summary"])
+                if selectors.get("listing_summary")
+                else None,
+        ),
+        headers=payload.get("headers", {}),
+        date_format=payload.get("date_format", "%Y-%m-%d"),
+    )
+
+
+def _article_to_payload(article: Article) -> dict:
+    return {
+        "portal": article.portal_name,
+        "title": article.title,
+        "url": article.url,
+        "content": article.content,
+        "summary": article.summary,
+        "published_at": article.published_at.isoformat(),
+    }
+
+
+def _article_from_payload(payload: dict) -> Article:
+    return Article(
+        portal_name=payload["portal"],
+        title=payload["title"],
+        url=payload["url"],
+        content=payload["content"],
+        summary=payload.get("summary"),
+        published_at=datetime.fromisoformat(payload["published_at"]),
+        raw=payload.get("raw", {}),
+    )
+
+
+class PortalServiceClient(PortalGateway):
+    """HTTP implementation of :class:`PortalGateway`."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: httpx.Client | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        if client is None:
+            self._client = httpx.Client(base_url=self._base_url, timeout=timeout)
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+
+    def get_portal(self, name: str) -> Optional[Portal]:
+        response = self._client.get("/portals")
+        response.raise_for_status()
+        for payload in response.json():
+            if payload.get("name") == name:
+                return _portal_from_payload(payload)
+        return None
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+
+class PublicationsAPISink(ArticleSink):
+    """HTTP adapter that forwards new articles to the publications service."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: httpx.Client | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        if client is None:
+            self._client = httpx.Client(base_url=self._base_url, timeout=timeout)
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+
+    def publish_many(self, articles: Iterable[Article]) -> Iterable[Article]:
+        payload = [_article_to_payload(article) for article in articles]
+        if not payload:
+            return []
+        response = self._client.post("/articles/batch", json={"articles": payload})
+        response.raise_for_status()
+        body = response.json()
+        stored = body.get("stored", [])
+        return [_article_from_payload(item) for item in stored]
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+
+__all__ = ["PortalServiceClient", "PublicationsAPISink"]

--- a/sentinela/services/news/container.py
+++ b/sentinela/services/news/container.py
@@ -1,48 +1,57 @@
 """Dependency container for news collection services."""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+from typing import Callable
 
 from sentinela.application.services import NewsCollectorService
-from sentinela.infrastructure.database import MongoClientFactory
-from sentinela.infrastructure.repositories import (
-    MongoArticleRepository,
-    MongoPortalRepository,
-)
 from sentinela.infrastructure.scraper import RequestsSoupScraper
+from sentinela.services.news.clients import (
+    PortalServiceClient,
+    PublicationsAPISink,
+)
 
 
 @dataclass
 class NewsContainer:
     """Container exposing news collection service dependencies."""
 
-    portal_repository: MongoPortalRepository
-    article_repository: MongoArticleRepository
+    portal_gateway: PortalServiceClient
+    article_sink: PublicationsAPISink
     scraper: RequestsSoupScraper
     collector_service: NewsCollectorService
 
 
 def build_news_container(
-    factory: MongoClientFactory | None = None,
+    *,
+    portals_url: str | None = None,
+    publications_url: str | None = None,
+    status_publisher: Callable[[str], None] | None = None,
 ) -> NewsContainer:
     """Build the news collection service container."""
 
-    factory = factory or MongoClientFactory()
-    database = factory.get_database()
+    portals_url = portals_url or os.getenv(
+        "PORTALS_SERVICE_URL", "http://localhost:8001"
+    )
+    publications_url = publications_url or os.getenv(
+        "PUBLICATIONS_SERVICE_URL", "http://localhost:8002"
+    )
 
-    portal_repository = MongoPortalRepository(database["portals"])
-    article_repository = MongoArticleRepository(database["articles"])
+    portal_gateway = PortalServiceClient(portals_url)
+    article_sink = PublicationsAPISink(publications_url)
     scraper = RequestsSoupScraper()
 
     collector_service = NewsCollectorService(
-        portal_repository=portal_repository,
-        article_repository=article_repository,
+        portal_gateway=portal_gateway,
+        article_sink=article_sink,
         scraper=scraper,
+        status_publisher=status_publisher,
     )
 
     return NewsContainer(
-        portal_repository=portal_repository,
-        article_repository=article_repository,
+        portal_gateway=portal_gateway,
+        article_sink=article_sink,
         scraper=scraper,
         collector_service=collector_service,
     )

--- a/sentinela/services/publications/adapters.py
+++ b/sentinela/services/publications/adapters.py
@@ -1,0 +1,74 @@
+"""Adapters for ingesting new articles into the publications service."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from sentinela.domain.entities import Article
+from sentinela.domain.repositories import ArticleRepository
+
+
+class ArticlePayload(BaseModel):
+    """Payload representing an article received from another service."""
+
+    portal: str
+    title: str
+    url: str
+    content: str
+    published_at: datetime
+    summary: str | None = None
+
+    def to_domain(self) -> Article:
+        return Article(
+            portal_name=self.portal,
+            title=self.title,
+            url=self.url,
+            content=self.content,
+            summary=self.summary,
+            published_at=self.published_at,
+        )
+
+
+class ArticleBatchPayload(BaseModel):
+    """Collection of articles ingested in a single request."""
+
+    articles: list[ArticlePayload] = Field(default_factory=list)
+
+    def to_domain(self) -> Iterable[Article]:
+        for payload in self.articles:
+            yield payload.to_domain()
+
+
+def create_ingestion_router(repository: ArticleRepository) -> APIRouter:
+    """Create a router exposing endpoints for ingesting new articles."""
+
+    router = APIRouter(prefix="/articles", tags=["Ingestão"])
+
+    def serialize(article: Article) -> dict:
+        return {
+            "portal": article.portal_name,
+            "title": article.title,
+            "url": article.url,
+            "content": article.content,
+            "summary": article.summary,
+            "published_at": article.published_at.isoformat(),
+        }
+
+    @router.post("/batch")
+    def ingest_articles(payload: ArticleBatchPayload) -> dict:
+        articles = list(payload.to_domain())
+        new_articles: list[Article] = []
+        for article in articles:
+            if not repository.exists(article.portal_name, article.url):
+                new_articles.append(article)
+        if new_articles:
+            repository.save_many(new_articles)
+        return {"stored": [serialize(article) for article in new_articles]}
+
+    return router
+
+
+__all__ = ["create_ingestion_router", "ArticlePayload", "ArticleBatchPayload"]

--- a/sentinela/services/publications/api.py
+++ b/sentinela/services/publications/api.py
@@ -16,6 +16,7 @@ from sentinela.services.publications import (
     PublicationsContainer,
     build_publications_container,
 )
+from sentinela.services.publications.adapters import create_ingestion_router
 
 
 class EnrichedCandidateResponse(BaseModel):
@@ -172,6 +173,8 @@ def include_routes(
         return [map_article_response(article) for article in articles]
 
     app.include_router(router)
+    ingestion_router = create_ingestion_router(container.article_repository)
+    app.include_router(ingestion_router, prefix=prefix)
 
 
 def create_app() -> FastAPI:

--- a/sentinela/services/publications/container.py
+++ b/sentinela/services/publications/container.py
@@ -1,11 +1,11 @@
-"""Dependency container for publications queries."""
+"""Dependency container for publications queries and ingestion."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from sentinela.application.services import ArticleQueryService
 from sentinela.infrastructure.database import MongoClientFactory
-from sentinela.infrastructure.repositories import MongoArticleReadRepository
+from sentinela.infrastructure.repositories import MongoArticleRepository
 from sentinela.services.extraction import ExtractionResultStore, get_default_result_store
 
 
@@ -13,7 +13,7 @@ from sentinela.services.extraction import ExtractionResultStore, get_default_res
 class PublicationsContainer:
     """Container exposing publication query dependencies."""
 
-    article_repository: MongoArticleReadRepository
+    article_repository: MongoArticleRepository
     query_service: ArticleQueryService
     extraction_store: ExtractionResultStore
 
@@ -26,7 +26,7 @@ def build_publications_container(
     factory = factory or MongoClientFactory()
     database = factory.get_database()
 
-    article_repository = MongoArticleReadRepository(database["articles"])
+    article_repository = MongoArticleRepository(database["articles"])
     query_service = ArticleQueryService(article_repository)
 
     return PublicationsContainer(


### PR DESCRIPTION
## Summary
- define domain ports representing remote portal configuration access and article ingestion
- refactor NewsCollectorService to depend on the new ports with optional status publisher support
- add HTTP clients and FastAPI adapters wiring services together via REST instead of shared Mongo

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1906e8e08832b9e7285e7714a55ac