### PR TITLE
Separate publications service domain and infrastructure

### DIFF
--- a/sentinela/services/publications/adapters/ingestion_router.py
+++ b/sentinela/services/publications/adapters/ingestion_router.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from sentinela.domain import Article
-from sentinela.domain.repositories import ArticleRepository
+from sentinela.services.publications.domain import Article
+from sentinela.services.publications.domain.repositories import ArticleRepository
 
 from ..schemas import ArticleBatchPayload
 

--- a/sentinela/services/publications/api.py
+++ b/sentinela/services/publications/api.py
@@ -11,11 +11,11 @@ from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from sentinela.domain import Article
 from sentinela.services.publications import (
     PublicationsContainer,
     build_publications_container,
 )
+from sentinela.services.publications.domain import Article
 from sentinela.services.publications.adapters import create_ingestion_router
 
 

--- a/sentinela/services/publications/application/__init__.py
+++ b/sentinela/services/publications/application/__init__.py
@@ -1,0 +1,5 @@
+"""Camada de aplicação do serviço de publicações."""
+
+from .query_service import ArticleQueryService
+
+__all__ = ["ArticleQueryService"]

--- a/sentinela/services/publications/application/query_service.py
+++ b/sentinela/services/publications/application/query_service.py
@@ -1,0 +1,27 @@
+"""Casos de uso relacionados à consulta de publicações."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Iterable
+
+from ..domain import Article
+from ..domain.repositories import ArticleReadRepository
+
+
+class ArticleQueryService:
+    """Fornece acesso somente leitura aos artigos armazenados."""
+
+    def __init__(self, repository: ArticleReadRepository) -> None:
+        self._repository = repository
+
+    def list_articles(
+        self, portal_name: str, start_date: date, end_date: date
+    ) -> Iterable[Article]:
+        """Lista artigos publicados dentro do intervalo de datas informado."""
+
+        start_dt = datetime.combine(start_date, datetime.min.time())
+        end_dt = datetime.combine(end_date, datetime.max.time())
+        return self._repository.list_by_period(portal_name, start_dt, end_dt)
+
+
+__all__ = ["ArticleQueryService"]

--- a/sentinela/services/publications/container.py
+++ b/sentinela/services/publications/container.py
@@ -1,21 +1,23 @@
-"""Dependency container for publications queries and ingestion."""
+"""Dependency container for the publications service."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-from sentinela.application.services import ArticleQueryService
 from sentinela.infrastructure.database import MongoClientFactory
-from sentinela.infrastructure.repositories import MongoArticleRepository
 from sentinela.services.extraction import ExtractionResultStore, get_default_result_store
+
+from .application import ArticleQueryService
+from .infrastructure import MongoArticleReadRepository, MongoArticleRepository
 
 
 @dataclass
 class PublicationsContainer:
-    """Container exposing publication query dependencies."""
+    """Container exposing the service dependencies for publications."""
 
     article_repository: MongoArticleRepository
     query_service: ArticleQueryService
     extraction_store: ExtractionResultStore
+    article_reader: MongoArticleReadRepository | None = None
 
 
 def build_publications_container(
@@ -26,11 +28,14 @@ def build_publications_container(
     factory = factory or MongoClientFactory()
     database = factory.get_database()
 
-    article_repository = MongoArticleRepository(database["articles"])
-    query_service = ArticleQueryService(article_repository)
+    collection = database["articles"]
+    article_repository = MongoArticleRepository(collection)
+    article_reader = MongoArticleReadRepository(collection)
+    query_service = ArticleQueryService(article_reader)
 
     return PublicationsContainer(
         article_repository=article_repository,
         query_service=query_service,
         extraction_store=get_default_result_store(),
+        article_reader=article_reader,
     )

--- a/sentinela/services/publications/domain/__init__.py
+++ b/sentinela/services/publications/domain/__init__.py
@@ -1,0 +1,6 @@
+"""API pública do domínio interno do serviço de publicações."""
+
+from .entities import Article
+from .repositories import ArticleReadRepository, ArticleRepository
+
+__all__ = ["Article", "ArticleRepository", "ArticleReadRepository"]

--- a/sentinela/services/publications/domain/entities/__init__.py
+++ b/sentinela/services/publications/domain/entities/__init__.py
@@ -1,0 +1,5 @@
+"""Entidades utilizadas exclusivamente pelo serviço de publicações."""
+
+from .article import Article
+
+__all__ = ["Article"]

--- a/sentinela/services/publications/domain/entities/article.py
+++ b/sentinela/services/publications/domain/entities/article.py
@@ -1,0 +1,29 @@
+"""Entidades específicas do serviço de publicações."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class Article:
+    """Representa um artigo armazenado pelo serviço de publicações."""
+
+    #: Nome do portal responsável pela publicação do artigo.
+    portal_name: str
+    #: Título exibido quando o artigo foi coletado.
+    title: str
+    #: Endereço permanente utilizado para acessar o artigo.
+    url: str
+    #: Conteúdo textual normalizado do artigo.
+    content: str
+    #: Data e hora de publicação informadas pelo portal.
+    published_at: datetime
+    #: Resumo opcional disponibilizado na listagem de artigos.
+    summary: Optional[str] = None
+    #: Informações adicionais preservadas para auditoria e rastreabilidade.
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["Article"]

--- a/sentinela/services/publications/domain/repositories/__init__.py
+++ b/sentinela/services/publications/domain/repositories/__init__.py
@@ -1,0 +1,6 @@
+"""Repositórios utilizados pelo domínio de publicações."""
+
+from .article_read_repository import ArticleReadRepository
+from .article_repository import ArticleRepository
+
+__all__ = ["ArticleRepository", "ArticleReadRepository"]

--- a/sentinela/services/publications/domain/repositories/article_read_repository.py
+++ b/sentinela/services/publications/domain/repositories/article_read_repository.py
@@ -1,0 +1,21 @@
+"""Interfaces de leitura de artigos para o serviço de publicações."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Iterable
+
+from ..entities import Article
+
+
+class ArticleReadRepository(ABC):
+    """Fornece operações somente leitura sobre artigos publicados."""
+
+    @abstractmethod
+    def list_by_period(
+        self, portal_name: str, start: datetime, end: datetime
+    ) -> Iterable[Article]:
+        """Lista artigos de um portal que pertencem ao intervalo informado."""
+
+
+__all__ = ["ArticleReadRepository"]

--- a/sentinela/services/publications/domain/repositories/article_repository.py
+++ b/sentinela/services/publications/domain/repositories/article_repository.py
@@ -1,0 +1,29 @@
+"""Contratos de persistência específicos do serviço de publicações."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Iterable
+
+from ..entities import Article
+
+
+class ArticleRepository(ABC):
+    """Define operações de escrita para o contexto de publicações."""
+
+    @abstractmethod
+    def save_many(self, articles: Iterable[Article]) -> None:
+        """Persiste um conjunto de artigos no armazenamento definitivo."""
+
+    @abstractmethod
+    def exists(self, portal_name: str, url: str) -> bool:
+        """Verifica se já existe um artigo cadastrado para a combinação informada."""
+
+    @abstractmethod
+    def list_by_period(
+        self, portal_name: str, start: datetime, end: datetime
+    ) -> Iterable[Article]:
+        """Recupera artigos de um portal dentro do intervalo especificado."""
+
+
+__all__ = ["ArticleRepository"]

--- a/sentinela/services/publications/infrastructure/__init__.py
+++ b/sentinela/services/publications/infrastructure/__init__.py
@@ -1,0 +1,6 @@
+"""Infraestrutura dedicada ao serviço de publicações."""
+
+from .mongo_article_read_repository import MongoArticleReadRepository
+from .mongo_article_repository import MongoArticleRepository
+
+__all__ = ["MongoArticleRepository", "MongoArticleReadRepository"]

--- a/sentinela/services/publications/infrastructure/mongo_article_read_repository.py
+++ b/sentinela/services/publications/infrastructure/mongo_article_read_repository.py
@@ -1,0 +1,41 @@
+"""Implementação MongoDB do repositório somente leitura de publicações."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from pymongo.collection import Collection
+
+from ..domain import Article
+from ..domain.repositories import ArticleReadRepository
+
+
+class MongoArticleReadRepository(ArticleReadRepository):
+    """Consulta artigos persistidos no MongoDB sem permitir alterações."""
+
+    def __init__(self, collection: Collection) -> None:
+        self._collection: Collection = collection
+        """Coleção MongoDB da qual os artigos são consultados."""
+
+    def list_by_period(
+        self, portal_name: str, start: datetime, end: datetime
+    ) -> Iterable[Article]:
+        cursor = self._collection.find(
+            {
+                "portal_name": portal_name,
+                "published_at": {"$gte": start, "$lte": end},
+            }
+        ).sort("published_at", 1)
+        for data in cursor:
+            yield Article(
+                portal_name=data["portal_name"],
+                title=data["title"],
+                url=data["url"],
+                content=data["content"],
+                summary=data.get("summary"),
+                published_at=data["published_at"],
+                raw=data.get("raw", {}),
+            )
+
+
+__all__ = ["MongoArticleReadRepository"]

--- a/sentinela/services/publications/infrastructure/mongo_article_repository.py
+++ b/sentinela/services/publications/infrastructure/mongo_article_repository.py
@@ -1,0 +1,84 @@
+"""Implementação MongoDB do repositório de artigos de publicações."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from pymongo.collection import Collection
+
+from ..domain import Article
+from ..domain.repositories import ArticleRepository
+
+
+class MongoArticleRepository(ArticleRepository):
+    """Persiste entidades :class:`Article` utilizando MongoDB."""
+
+    def __init__(self, collection: Collection) -> None:
+        self._collection: Collection = collection
+        """Coleção MongoDB responsável por armazenar os artigos."""
+
+        self._collection.create_index(
+            [
+                ("portal_name", 1),
+                ("url", 1),
+            ],
+            unique=True,
+            background=True,
+        )
+        self._collection.create_index(
+            [
+                ("portal_name", 1),
+                ("published_at", 1),
+            ],
+            background=True,
+        )
+
+    def save_many(self, articles: Iterable[Article]) -> None:
+        documents = [self._serialize_article(article) for article in articles]
+        if documents:
+            self._collection.insert_many(documents, ordered=False)
+
+    def exists(self, portal_name: str, url: str) -> bool:
+        return (
+            self._collection.count_documents(
+                {"portal_name": portal_name, "url": url}, limit=1
+            )
+            > 0
+        )
+
+    def list_by_period(
+        self, portal_name: str, start: datetime, end: datetime
+    ) -> Iterable[Article]:
+        cursor = self._collection.find(
+            {
+                "portal_name": portal_name,
+                "published_at": {"$gte": start, "$lte": end},
+            }
+        ).sort("published_at", 1)
+        for data in cursor:
+            yield self._deserialize_article(data)
+
+    def _serialize_article(self, article: Article) -> dict:
+        return {
+            "portal_name": article.portal_name,
+            "title": article.title,
+            "url": article.url,
+            "content": article.content,
+            "summary": article.summary,
+            "published_at": article.published_at,
+            "raw": article.raw,
+        }
+
+    def _deserialize_article(self, data: dict) -> Article:
+        return Article(
+            portal_name=data["portal_name"],
+            title=data["title"],
+            url=data["url"],
+            content=data["content"],
+            summary=data.get("summary"),
+            published_at=data["published_at"],
+            raw=data.get("raw", {}),
+        )
+
+
+__all__ = ["MongoArticleRepository"]

--- a/sentinela/services/publications/schemas/article_batch_payload.py
+++ b/sentinela/services/publications/schemas/article_batch_payload.py
@@ -5,7 +5,7 @@ from typing import Iterable
 
 from pydantic import BaseModel, Field
 
-from sentinela.domain import Article
+from sentinela.services.publications.domain import Article
 
 from .article_payload import ArticlePayload
 

--- a/sentinela/services/publications/schemas/article_payload.py
+++ b/sentinela/services/publications/schemas/article_payload.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-from sentinela.domain import Article
+from sentinela.services.publications.domain import Article
 
 
 class ArticlePayload(BaseModel):


### PR DESCRIPTION
## Summary
- create a dedicated domain, application and infrastructure layer under the publications service
- update the publications container, API and schemas to depend on the new domain instead of the shared news domain
- keep backwards compatibility while wiring the container with MongoDB repositories specialised for publications

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d20b381c90832b8217c75ad397170c