### PR TITLE
Create shared DTO TypeScript package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .pytest_cache/
+node_modules/
+packages/@types/dist/

--- a/packages/@types/README.md
+++ b/packages/@types/README.md
@@ -1,0 +1,14 @@
+# @sentinela/types
+
+Pacote com Data Transfer Objects (DTOs) compartilhados entre os serviços do ecossistema Sentinela.
+
+## Desenvolvimento
+
+Instale dependências e gere declarações TypeScript:
+
+```bash
+npm install
+npm run build
+```
+
+O comando `build` gera apenas arquivos de declaração (`.d.ts`) na pasta `dist/`.

--- a/packages/@types/package.json
+++ b/packages/@types/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sentinela/types",
+  "version": "0.1.0",
+  "description": "DTO definitions compartilhadas entre serviços do projeto Sentinela.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "keywords": [
+    "sentinela",
+    "types",
+    "dto"
+  ],
+  "author": "Sentinela",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.3.0"
+  }
+}

--- a/packages/@types/src/dtos/comment.ts
+++ b/packages/@types/src/dtos/comment.ts
@@ -1,0 +1,10 @@
+import type { User } from "./user";
+
+export interface Comment {
+  id: string;
+  taskId: string;
+  authorId: User["id"];
+  content: string;
+  createdAt: string;
+  updatedAt?: string;
+}

--- a/packages/@types/src/dtos/task.ts
+++ b/packages/@types/src/dtos/task.ts
@@ -1,0 +1,16 @@
+import type { User } from "./user";
+import type { Comment } from "./comment";
+
+export type TaskStatus = "pending" | "in_progress" | "completed" | "archived";
+
+export interface Task {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  createdAt: string;
+  updatedAt?: string;
+  dueDate?: string;
+  assignedTo?: User["id"];
+  comments?: Comment[];
+}

--- a/packages/@types/src/dtos/tokens.ts
+++ b/packages/@types/src/dtos/tokens.ts
@@ -1,0 +1,6 @@
+export interface Tokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  tokenType?: string;
+}

--- a/packages/@types/src/dtos/user.ts
+++ b/packages/@types/src/dtos/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  createdAt: string;
+  updatedAt?: string;
+}

--- a/packages/@types/src/index.ts
+++ b/packages/@types/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./dtos/user";
+export * from "./dtos/tokens";
+export * from "./dtos/task";
+export * from "./dtos/comment";

--- a/packages/@types/tsconfig.build.json
+++ b/packages/@types/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}

--- a/packages/@types/tsconfig.json
+++ b/packages/@types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## Summary
- add the `@sentinela/types` package containing initial DTOs for user, tokens, task and comment models
- configure TypeScript compilation settings for the new package and share a base config at the repo root
- update the gitignore to exclude Node build outputs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dffc81c46c832b953da7b10e7d0fd2